### PR TITLE
Remove SiteID, merge Pick and Beam formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ seismic event detections.
 ## Defined formats:
 * [Pick](format-docs/Pick.md) Format - A format for unassociated picks from a
 waveform arrival time picking algorithm.
-* [Beam](format-docs/Beam.md) Format  - A format for unassociated beams from
-seismic array beamforming algorithm.
 * [Correlation](format-docs/Correlation.md) Format - A format to contain a
 seismic event detection made using a cross correlation algorithm.
 * [Detection](format-docs/Detection.md) Format - A format to contain a seismic
@@ -30,18 +28,20 @@ event detection generated using an event detection or association algorithm.
 retraction made using an event detection algorithm.
 
 ## Supporting objects:
-* [Hypocenter](format-docs/Hypocenter.md) Object - An object that contains information about
-a hypocenter as part of a detection.
+* [Hypocenter](format-docs/Hypocenter.md) Object - An object that contains
+information about a hypocenter as part of a detection.
 * [Amplitude](format-docs/Amplitude.md) Object - An object that contains
 information about an amplitude as part of a pick.
+* [Beam](format-docs/Beam.md) Object  - An object that contains information
+about a waveform beam as part of a pick.
 * [Associated](format-docs/Associated.md) Object - An object that contains
-associated information if a pick, beam, or correlation is included in an origin.
+associated information if a pick, beam, or correlation is included in an detection.
 * [Filter](format-docs/Filter.md) Object - An object that contains filter
 information as part of a pick.
 * [Site](format-docs/Site.md) Object - An object that defines the station used
 to create a pick, beam, correlation,
 * [Source](format-docs/Source.md) Object - An object that defines the
-creator/source of a pick, beam, correlation, or origin
+creator/source of a pick, correlation, or detection
 
 ## Supported Languages:
 Currently a library written in C++11, and a Java 1.7 jar file exist to generate

--- a/cpp/include/beam.h
+++ b/cpp/include/beam.h
@@ -11,7 +11,6 @@
 
 #include "site.h"
 #include "source.h"
-#include "associated.h"
 
 namespace detectionformats {
 
@@ -43,138 +42,20 @@ public:
 	 * The advanced constructor for the beam class.
 	 * Initilizes members to provided values.
 	 *
-	 * \param newid - A std::string containing the id to use
-	 * \param newsiteid - A std::string containing the siteid to use
-	 * \param newstation - A std::string containing the station to use
-	 * \param newchannel - A std::string containing the channel to use
-	 * \param newnetwork - A std::string containing the network to use
-	 * \param newlocation - A std::string containing the location to use
-	 * \param newagencyid - A std::string containing the agencyid to use
-	 * \param newauthor - A std::string containing the author to use
-	 * \param newstarttime - A double containing the new start time to use
-	 * \param newendtime - A double containing the new end time to use
 	 * \param newbackazimuth - A double containing the back azimuth to use
 	 * \param newbackazimutherror - A double containing the back azimuth error
 	 * to use, std::numeric_limits<double>::quiet_NaN() to omit
 	 * \param newslowness - A double containing the slowness to use
 	 * \param newslownesserror - A double containing the slowness error to use,
 	 * std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newpowerratio - A double containing the powerratio to use
-	 * \param newpowerratioerror - A double containing the powerratio error to use,
+	 * \param newpowerratio - A double containing the powerratio to use,
 	 * std::numeric_limits<double>::quiet_NaN() to omit
-	 */
-	beam(std::string newid, std::string newsiteid, std::string newstation,
-			std::string newchannel, std::string newnetwork,
-			std::string newlocation, std::string newagencyid,
-			std::string newauthor, double newstarttime, double newendtime,
-			double newbackazimuth, double newbackazimutherror,
-			double newslowness, double newslownesserror, double newpowerratio,
-			double newpowerratioerror);
-
-	/**
-	 * \brief beam advanced constructor
-	 *
-	 * The advanced constructor for the beam class.
-	 * Initilizes members to provided values.
-	 *
-	 * \param newid - A std::string containing the id to use
-	 * \param newsiteid - A std::string containing the siteid to use
-	 * \param newstation - A std::string containing the station to use
-	 * \param newchannel - A std::string containing the channel to use
-	 * \param newnetwork - A std::string containing the network to use
-	 * \param newlocation - A std::string containing the location to use
-	 * \param newagencyid - A std::string containing the agencyid to use
-	 * \param newauthor - A std::string containing the author to use
-	 * \param newstarttime - A double containing the new start time to use
-	 * \param newendtime - A double containing the new end time to use
-	 * \param newbackazimuth - A double containing the back azimuth to use
-	 * \param newbackazimutherror - A double containing the back azimuth error
-	 * to use, std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newslowness - A double containing the slowness to use
-	 * \param newslownesserror - A double containing the slowness error to use,
-	 * std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newpowerratio - A double containing the powerratio to use
-	 * \param newpowerratioerror - A double containing the powerratio error to use,
-	 * std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newassociatedphase - A std:string containing the associated phase
-	 * to use, empty string to omit
-	 * \param newassociateddistance - A double containing the associated
-	 * distance to use, std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newassociatedazimuth - A double containing the associated azimuth
-	 * to use, std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newassociatedresidual - A double containing the associated
-	 * residual to use, std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newassociatedsigma - A double containing the associated sigma to
+	 * \param newpowerratioerror - A double containing the powerratio error to
 	 * use, std::numeric_limits<double>::quiet_NaN() to omit
 	 */
-	beam(std::string newid, std::string newsiteid, std::string newstation,
-			std::string newchannel, std::string newnetwork,
-			std::string newlocation, std::string newagencyid,
-			std::string newauthor, double newstarttime, double newendtime,
-			double newbackazimuth, double newbackazimutherror,
-			double newslowness, double newslownesserror, double newpowerratio,
-			double newpowerratioerror,  std::string newassociatedphase,
-			double newassociateddistance, double newassociatedazimuth,
-			double newassociatedresidual, double newassociatedsigma);
-
-	/**
-	 * \brief beam alternate advanced constructor
-	 *
-	 * The alternate advanced constructor for the beam class.
-	 * Initilizes members to provided values.
-	 *
-	 * \param newid - A std::string containing the id to use
-	 * \param newsite - A detectionformats::site containing the site to use
-	 * \param newsource - A detectionformats::source containing the source to
-	 * use
-	 * \param newstarttime - A double containing the new start time to use
-	 * \param newendtime - A double containing the new end time to use
-	 * \param newbackazimuth - A double containing the back azimuth to use
-	 * \param newbackazimutherror - A double containing the back azimuth error
-	 * to use, std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newslowness - A double containing the slowness to use
-	 * \param newslownesserror - A double containing the slowness error to use,
-	 * std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newpowerratio - A double containing the powerratio to use
-	 * \param newpowerratioerror - A double containing the powerratio error to use,
-	 * std::numeric_limits<double>::quiet_NaN() to omit
-	 */
-	beam(std::string newid, detectionformats::site newsite,
-			detectionformats::source newsource, double newstarttime,
-			double newendtime, double newbackazimuth,
-			double newbackazimutherror, double newslowness,
-			double newslownesserror, double newpowerratio, double newpowerratioerror);
-
-	/**
-	 * \brief beam alternate advanced constructor
-	 *
-	 * The alternate advanced constructor for the beam class.
-	 * Initilizes members to provided values.
-	 *
-	 * \param newid - A std::string containing the id to use
-	 * \param newsite - A detectionformats::site containing the site to use
-	 * \param newsource - A detectionformats::source containing the source to
-	 * use
-	 * \param newstarttime - A double containing the new start time to use
-	 * \param newendtime - A double containing the new end time to use
-	 * \param newbackazimuth - A double containing the back azimuth to use
-	 * \param newbackazimutherror - A double containing the back azimuth error
-	 * to use, std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newslowness - A double containing the slowness to use
-	 * \param newslownesserror - A double containing the slowness error to use,
-	 * std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newpowerratio - A double containing the powerratio to use
-	 * \param newpowerratioerror - A double containing the powerratio error to use,
-	 * std::numeric_limits<double>::quiet_NaN() to omit
-	 * \param newassociated - A detectionformats::associated containing the
-	 * associated to use
-	 */
-	beam(std::string newid, detectionformats::site newsite,
-			detectionformats::source newsource, double newstarttime,
-			double newendtime, double newbackazimuth,
-			double newbackazimutherror, double newslowness,
-			double newslownesserror, double newpowerratio, double newpowerratioerror,
-			detectionformats::associated newassociated);
+	beam(double newbackazimuth, double newbackazimutherror, double newslowness,
+			double newslownesserror, double newpowerratio,
+			double newpowerratioerror);
 
 	/**
 	 * \brief beam advanced constructor
@@ -221,41 +102,12 @@ public:
 	virtual std::vector<std::string> geterrors() override;
 
 	/**
-	 * \brief beam id
-	 *
-	 * A required std::string containing the id of this beam message
-	 */
-	std::string id;
-
-	/**
-	 * \brief beam site
-	 *
-	 * A required detectionformats::site containing the site for this beam
-	 * message
-	 */
-	detectionformats::site site;
-
-	/**
-	 * \brief beam source
-	 *
-	 * A required detectionformats::source containing the source for this beam
-	 * message
-	 */
-	detectionformats::source source;
-
-	/**
-	 * \brief beam start time
-	 *
-	 * A required double containing the starting time for this beam message
-	 */
-	double starttime;
-
-	/**
-	 * \brief beam end time
-	 *
-	 * A required double containing the ending time for this beam message
-	 */
-	double endtime;
+	* \brief Empty check
+	*
+	* Checks to see if this object is empty
+	* \return Returns true if empty, false otherwise.
+	*/
+	bool isempty();
 
 	/**
 	 * \brief beam back azimuth
@@ -288,7 +140,7 @@ public:
 	/**
 	 * \brief beam powerratio
 	 *
-	 * A required double defining the powerratio of this beam message
+	 * An optional double defining the powerratio of this beam message
 	 */
 	double powerratio;
 
@@ -298,14 +150,6 @@ public:
 	 * An optional double defining the powerratio error of this beam message
 	 */
 	double powerratioerror;
-
-	/**
-	 * \brief beam associated
-	 *
-	 * Optional detectionformats::associated containing the associated
-	 * information for this beam message
-	 */
-	detectionformats::associated associationinfo;
 
 protected:
 

--- a/cpp/include/correlation.h
+++ b/cpp/include/correlation.h
@@ -45,7 +45,6 @@ public:
 	 * Initilizes members to provided values.
 	 *
 	 * \param newid - A std::string containing the id to use
-	 * \param newsiteid - A std::string containing the siteid to use
 	 * \param newstation - A std::string containing the station to use
 	 * \param newchannel - A std::string containing the channel to use
 	 * \param newnetwork - A std::string containing the network to use
@@ -80,16 +79,16 @@ public:
 	 * \param newthresholdtype - A std::string containing the threshold type to
 	 * 		use, empty string to omit
 	 */
-	correlation(std::string newid, std::string newsiteid,
-			std::string newstation, std::string newchannel,
-			std::string newnetwork, std::string newlocation,
-			std::string newagencyid, std::string newauthor,
-			std::string newphase, double newtime, double newcorrelation,
-			double newlatitude, double newlongitude, double neworigintime,
-			double newdepth, double newlatitudeerror, double newlongitudeerror,
-			double newtimeerror, double newdeptherror, std::string neweventtype,
-			double newmagnitude, double newsnr, double newzscore,
-			double newdetectionthreshold, std::string newthresholdtype);
+	correlation(std::string newid, std::string newstation,
+			std::string newchannel, std::string newnetwork,
+			std::string newlocation, std::string newagencyid,
+			std::string newauthor, std::string newphase, double newtime,
+			double newcorrelation, double newlatitude, double newlongitude,
+			double neworigintime, double newdepth, double newlatitudeerror,
+			double newlongitudeerror, double newtimeerror, double newdeptherror,
+			std::string neweventtype, double newmagnitude, double newsnr,
+			double newzscore, double newdetectionthreshold,
+			std::string newthresholdtype);
 
 	/**
 	 * \brief correlation advanced constructor
@@ -98,7 +97,6 @@ public:
 	 * Initilizes members to provided values.
 	 *
 	 * \param newid - A std::string containing the id to use
-	 * \param newsiteid - A std::string containing the siteid to use
 	 * \param newstation - A std::string containing the station to use
 	 * \param newchannel - A std::string containing the channel to use
 	 * \param newnetwork - A std::string containing the network to use
@@ -143,19 +141,18 @@ public:
 	 * \param newassociatedsigma - A double containing the associated sigma to
 	 * 		use, std::numeric_limits<double>::quiet_NaN() to omit
 	 */
-	correlation(std::string newid, std::string newsiteid,
-			std::string newstation, std::string newchannel,
-			std::string newnetwork, std::string newlocation,
-			std::string newagencyid, std::string newauthor,
-			std::string newphase, double newtime, double newcorrelation,
-			double newlatitude, double newlongitude, double neworigintime,
-			double newdepth, double newlatitudeerror, double newlongitudeerror,
-			double newtimeerror, double newdeptherror, std::string neweventtype,
-			double newmagnitude, double newsnr, double newzscore,
-			double newdetectionthreshold, std::string newthresholdtype,
-			std::string newassociatedphase, double newassociateddistance,
-			double newassociatedazimuth, double newassociatedresidual,
-			double newassociatedsigma);
+	correlation(std::string newid, std::string newstation,
+			std::string newchannel, std::string newnetwork,
+			std::string newlocation, std::string newagencyid,
+			std::string newauthor, std::string newphase, double newtime,
+			double newcorrelation, double newlatitude, double newlongitude,
+			double neworigintime, double newdepth, double newlatitudeerror,
+			double newlongitudeerror, double newtimeerror, double newdeptherror,
+			std::string neweventtype, double newmagnitude, double newsnr,
+			double newzscore, double newdetectionthreshold,
+			std::string newthresholdtype, std::string newassociatedphase,
+			double newassociateddistance, double newassociatedazimuth,
+			double newassociatedresidual, double newassociatedsigma);
 
 	/**
 	 * \brief correlation alternate advanced constructor

--- a/cpp/include/detection.h
+++ b/cpp/include/detection.h
@@ -10,18 +10,18 @@
 #include <string>
 #include <vector>
 
+#include "source.h"
 #include "hypocenter.h"
 #include "pick.h"
-#include "beam.h"
 #include "correlation.h"
 
 namespace detectionformats {
 /**
  * \brief detectionformats detection conversion class
  *
- * The detectionformats detection class is a conversion class used to create, parse,
- * and validate the event detection data format detection.  The detection format uses
- * the JSON standard (www.json.org)
+ * The detectionformats detection class is a conversion class used to create,
+ * parse, and validate the event detection data format detection.  The detection
+ * format uses the JSON standard (www.json.org)
  *
  * detection is intended for use in seismic data messaging between seismic
  * applications and organizations.
@@ -49,7 +49,8 @@ public:
 	 * \param newauthor - A std::string containing the author to use
 	 * \param newlatitude - A double containing the latitude to use
 	 * \param newlongitude - A double containing the longitude to use
-	 * \param newdetectiontime - A double containing the new detection time to use
+	 * \param newdetectiontime - A double containing the new detection time to
+	 * use
 	 * \param newdepth - A double containing the depth to use
 	 * \param newlatitudeerror - A double containing the latitude error to use,
 	 * 		std::numeric_limits<double>::quiet_NaN() to omit
@@ -70,12 +71,11 @@ public:
 	 * \param newgap - A double containing the gap to use,
 	 * 		std::numeric_limits<double>::quiet_NaN() to omit
 	 * \param newpickdata - A std::vector<detectionformats::pickjson> newdata
-	 * 		containing the data that went into this detection, empty vector to omit
-	 * \param newbeamdata - A std::vector<detectionformats::beamjson> newdata
-	 * 		containing the data that went into this detection, empty vector to omit
+	 * 		containing the data that went into this detection, empty vector to
+	 * 		omit
 	 * \param newcorrelationdata - A std::vector<detectionformats::correlationjson>
-	 * 		newdata containing the data that went into this detection, empty vector
-	 * 		to omit
+	 * 		newdata containing the data that went into this detection, empty
+	 * 		vector to omit
 	 */
 	detection(std::string newid, std::string newagencyid, std::string newauthor,
 			double newlatitude, double newlongitude, double newdetectiontime,
@@ -84,7 +84,6 @@ public:
 			std::string newdetectiontype, std::string neweventtype,
 			double newbayes, double newminimumdistance, double newrms,
 			double newgap, std::vector<detectionformats::pick> newpickdata,
-			std::vector<detectionformats::beam> newbeamdata,
 			std::vector<detectionformats::correlation> newcorrelationdata);
 
 	/**
@@ -96,10 +95,10 @@ public:
 	 * \param newid - A std::string containing the id to use
 	 * \param newsource - A detectionformats::source containing the source to
 	 * 		use
-	 * \param newhypocenter - A detectionformats::hypocenter containing the hypocenter
-	 * 		to use
-	 * \param newdetectiontype - A std::string containing the detection type to use,
-	 * 		empty string to omit
+	 * \param newhypocenter - A detectionformats::hypocenter containing the
+	 * 		hypocenter to use
+	 * \param newdetectiontype - A std::string containing the detection type to
+	 * 		use, empty string to omit
 	 * \param neweventtype - A std::string containing the event type to use,
 	 * 		empty string to omit
 	 * \param newbayes - A double containing the bayes to use,
@@ -111,19 +110,17 @@ public:
 	 * \param newgap - A double containing the gap to use,
 	 * 		std::numeric_limits<double>::quiet_NaN() to omit
 	 * \param newpickdata - A std::vector<detectionformats::pickjson> newdata
-	 * 		containing the data that went into this detection, empty vector to omit
-	 * \param newbeamdata - A std::vector<detectionformats::beamjson> newdata
-	 * 		containing the data that went into this detection, empty vector to omit
+	 * 		containing the data that went into this detection, empty vector to
+	 * 		omit
 	 * \param newcorrelationdata - A std::vector<detectionformats::correlationjson>
-	 * 		newdata containing the data that went into this detection, empty vector
-	 * 		to omit
+	 * 		newdata containing the data that went into this detection, empty
+	 * 		vector to omit
 	 */
 	detection(std::string newid, detectionformats::source newsource,
 			detectionformats::hypocenter newhypocenter,
 			std::string newdetectiontype, std::string neweventtype,
 			double newbayes, double newminimumdistance, double newrms,
 			double newgap, std::vector<detectionformats::pick> newpickdata,
-			std::vector<detectionformats::beam> newbeamdata,
 			std::vector<detectionformats::correlation> newcorrelationdata);
 
 	/**
@@ -185,7 +182,7 @@ public:
 	detectionformats::source source;
 
 	/**
-	 * \brief correlation hypocenter
+	 * \brief detection hypocenter
 	 *
 	 * A required detectionformats::hypocenter defining the hypocenter of this
 	 * detection message
@@ -242,13 +239,6 @@ public:
 	 * An optional vector of pick objects used to generate this detection
 	 */
 	std::vector<detectionformats::pick> pickdata;
-
-	/**
-	 * \brief beam data vector
-	 *
-	 * An optional vector of beam objects used to generate this detection
-	 */
-	std::vector<detectionformats::beam> beamdata;
 
 	/**
 	 * \brief correlation data vector

--- a/cpp/include/pick.h
+++ b/cpp/include/pick.h
@@ -1,9 +1,9 @@
 /*****************************************
-* This file is documented for Doxygen.
-* If you modify this file please update
-* the comments so that Doxygen will still
-* be able to work.
-****************************************/
+ * This file is documented for Doxygen.
+ * If you modify this file please update
+ * the comments so that Doxygen will still
+ * be able to work.
+ ****************************************/
 #ifndef DETECTION_PICK_H
 #define DETECTION_PICK_H
 
@@ -13,266 +13,360 @@
 #include "source.h"
 #include "amplitude.h"
 #include "filter.h"
+#include "beam.h"
 #include "associated.h"
 
-namespace detectionformats
-{
+namespace detectionformats {
 
+/**
+ * \brief detectionformats pick conversion class
+ *
+ * The detectionformats pick class is a conversion class used to create, parse, and
+ * validate the unassociated pick data format pick.  The pick format uses
+ * the JSON standard (www.json.org)
+ *
+ * pick is intended for use in seismic data messaging between seismic
+ * applications and organizations.
+ *
+ * pick uses the Source and Site common objects.
+ */
+class pick: public detectionbase {
+public:
+	/**
+	 * \brief pick constructor
+	 *
+	 * The constructor for the pick class.
+	 * Initilizes members to null values.
+	 */
+	pick();
 
 	/**
-	* \brief detectionformats pick conversion class
-	*
-	* The detectionformats pick class is a conversion class used to create, parse, and
-	* validate the unassociated pick data format pick.  The pick format uses
-	* the JSON standard (www.json.org)
-	*
-	* pick is intended for use in seismic data messaging between seismic
-	* applications and organizations.
-	*
-	* pick uses the Source and Site common objects.
-	*/
-	class pick : public detectionbase
-	{
-	public:
-		/**
-		* \brief pick constructor
-		*
-		* The constructor for the pick class.
-		* Initilizes members to null values.
-		*/
-		pick();
+	 * \brief pick advanced constructor
+	 *
+	 * The advanced constructor for the pick class.
+	 * Initilizes members to provided values.
+	 *
+	 * \param newid - A std::string containing the id to use
+	 * \param newstation - A std::string containing the station to use
+	 * \param newchannel - A std::string containing the channel to use
+	 * \param newnetwork - A std::string containing the network to use
+	 * \param newlocation - A std::string containing the location to use
+	 * \param newtime - A double containing the new time to use
+	 * \param newagencyid - A std::string containing the agencyid to use
+	 * \param newauthor - A std::string containing the author to use
+	 * \param newphase - A std::string containing the phase to use, empty
+	 * string to omit
+	 * \param newpolarity - A std::string containing the polarity to use,
+	 * empty string to omit
+	 * \param newonset - A std::string containing the onset to use, empty
+	 * string to omit
+	 * \param newpicker - A std::string containing the picker to use, empty
+	 * string to omit
+	 * \param newhighpass - A double containing the high pass to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newlowpass - A double containing the low pass to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newamplitude - A double containing the amplitude to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newperiod - A double containing the period to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newsnr - A double containing the snr to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newbackazimuth - A double containing the back azimuth to use
+	 * \param newbackazimutherror - A double containing the back azimuth error
+	 * to use, std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newslowness - A double containing the slowness to use
+	 * \param newslownesserror - A double containing the slowness error to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newpowerratio - A double containing the powerratio to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newpowerratioerror - A double containing the powerratio error to
+	 * use, std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newassociatedphase - A std:string containing the associated
+	 * phase to use, empty string to omit
+	 * \param newassociateddistance - A double containing the associated
+	 * distance to use, std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newassociatedazimuth - A double containing the associated
+	 * azimuth to use, std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newassociatedresidual - A double containing the associated
+	 * residual to use, -10000 to omit
+	 * \param newassociatedsigma - A double containing the associated sigma
+	 * to use, std::numeric_limits<double>::quiet_NaN() to omit
+	 */
+	pick(std::string newid, std::string newstation, std::string newchannel,
+			std::string newnetwork, std::string newlocation, double newtime,
+			std::string newagencyid, std::string newauthor,
+			std::string newphase, std::string newpolarity, std::string newonset,
+			std::string newpicker, double newhighpass, double newlowpass,
+			double newamplitude, double newperiod, double newsnr,
+			double newbackazimuth, double newbackazimutherror,
+			double newslowness, double newslownesserror, double newpowerratio,
+			double newpowerratioerror, std::string newassociatedphase,
+			double newassociateddistance, double newassociatedazimuth,
+			double newassociatedresidual, double newassociatedsigma);
 
-		/**
-		* \brief pick advanced constructor
-		*
-		* The advanced constructor for the pick class.
-		* Initilizes members to provided values.
-		*
-		* \param newid - A std::string containing the id to use
-		* \param newsiteid - A std::string containing the siteid to use
-		* \param newstation - A std::string containing the station to use
-		* \param newchannel - A std::string containing the channel to use
-		* \param newnetwork - A std::string containing the network to use
-		* \param newlocation - A std::string containing the location to use
-		* \param newtime - A double containing the new time to use
-		* \param newagencyid - A std::string containing the agencyid to use
-		* \param newauthor - A std::string containing the author to use
-		* \param newphase - A std::string containing the phase to use, empty string to omit
-		* \param newpolarity - A std::string containing the polarity to use, empty string to omit
-		* \param newonset - A std::string containing the onset to use, empty string to omit
-		* \param newpicker - A std::string containing the picker to use, empty string to omit
-		* \param newhighpass - A double containing the high pass to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newlowpass - A double containing the low pass to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newamplitude - A double containing the amplitude to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newperiod - A double containing the period to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newsnr - A double containing the snr to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newassociatedphase - A std:string containing the associated phase to use, empty string to omit
-		* \param newassociateddistance - A double containing the associated distance to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newassociatedazimuth - A double containing the associated azimuth to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newassociatedresidual - A double containing the associated residual to use, -10000 to omit
-		* \param newassociatedsigma - A double containing the associated sigma to use, std::numeric_limits<double>::quiet_NaN() to omit
-		*/
-		pick(std::string newid, std::string newsiteid, std::string newstation, std::string newchannel, std::string newnetwork, std::string newlocation,
-			     double newtime, std::string newagencyid, std::string newauthor, std::string newphase, std::string newpolarity, std::string newonset,
-			     std::string newpicker, double newhighpass, double newlowpass, double newamplitude, double newperiod, double newsnr, std::string newassociatedphase,
-			     double newassociateddistance, double newassociatedazimuth, double newassociatedresidual, double newassociatedsigma);
+	/**
+	 * \brief pick advanced constructor
+	 *
+	 * The advanced constructor for the pick class.
+	 * Initilizes members to provided values.
+	 *
+	 * \param newid - A std::string containing the id to use
+	 * \param newstation - A std::string containing the station to use
+	 * \param newchannel - A std::string containing the channel to use
+	 * \param newnetwork - A std::string containing the network to use
+	 * \param newlocation - A std::string containing the location to use
+	 * \param newtime - A double containing the new time to use
+	 * \param newagencyid - A std::string containing the agencyid to use
+	 * \param newauthor - A std::string containing the author to use
+	 * \param newphase - A std::string containing the phase to use, empty
+	 * string to omit
+	 * \param newpolarity - A std::string containing the polarity to use, empty
+	 * string to omit
+	 * \param newonset - A std::string containing the onset to use, empty string
+	 * to omit
+	 * \param newpicker - A std::string containing the picker to use, empty
+	 * string to omit
+	 * \param newhighpass - A double containing the high pass to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newlowpass - A double containing the low pass to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newamplitude - A double containing the amplitude to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newperiod - A double containing the period to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newsnr - A double containing the snr to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newbackazimuth - A double containing the back azimuth to use
+	 * \param newbackazimutherror - A double containing the back azimuth error
+	 * to use, std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newslowness - A double containing the slowness to use
+	 * \param newslownesserror - A double containing the slowness error to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newpowerratio - A double containing the powerratio to use,
+	 * std::numeric_limits<double>::quiet_NaN() to omit
+	 * \param newpowerratioerror - A double containing the powerratio error to
+	 * use, std::numeric_limits<double>::quiet_NaN() to omit
+	 */
+	pick(std::string newid, std::string newstation, std::string newchannel,
+			std::string newnetwork, std::string newlocation, double,
+			std::string newagencyid, std::string newauthor,
+			std::string newphase, std::string newpolarity, std::string newonset,
+			std::string newpicker, double newhighpass, double newlowpass,
+			double newamplitude, double newperiod, double newsnr,
+			double newbackazimuth, double newbackazimutherror,
+			double newslowness, double newslownesserror, double newpowerratio,
+			double newpowerratioerror);
 
-		/**
-		* \brief pick advanced constructor
-		*
-		* The advanced constructor for the pick class.
-		* Initilizes members to provided values.
-		*
-		* \param newid - A std::string containing the id to use
-		* \param newsiteid - A std::string containing the siteid to use
-		* \param newstation - A std::string containing the station to use
-		* \param newchannel - A std::string containing the channel to use
-		* \param newnetwork - A std::string containing the network to use
-		* \param newlocation - A std::string containing the location to use
-		* \param newtime - A double containing the new time to use
-		* \param newagencyid - A std::string containing the agencyid to use
-		* \param newauthor - A std::string containing the author to use
-		* \param newphase - A std::string containing the phase to use, empty string to omit
-		* \param newpolarity - A std::string containing the polarity to use, empty string to omit
-		* \param newonset - A std::string containing the onset to use, empty string to omit
-		* \param newpicker - A std::string containing the picker to use, empty string to omit
-		* \param newhighpass - A double containing the high pass to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newlowpass - A double containing the low pass to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newamplitude - A double containing the amplitude to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newperiod - A double containing the period to use, std::numeric_limits<double>::quiet_NaN() to omit
-		* \param newsnr - A double containing the snr to use, std::numeric_limits<double>::quiet_NaN() to omit
-		*/
-		pick(std::string newid, std::string newsiteid, std::string newstation, std::string newchannel, std::string newnetwork, std::string newlocation,
-			     double, std::string newagencyid, std::string newauthor, std::string newphase, std::string newpolarity, std::string newonset,
-			     std::string newpicker, double newhighpass, double newlowpass, double newamplitude, double newperiod, double newsnr);
+	/**
+	 * \brief pick alternate advanced constructor
+	 *
+	 * The alternate advanced constructor for the pick class.
+	 * Initilizes members to provided values.
+	 *
+	 * \param newid - A std::string containing the id to use
+	 * \param newsite - A detectionformats::site containing the site to use
+	 * \param newtime - A double containing the new time to use
+	 * \param newsource - A detectionformats::source containing the source to
+	 * use
+	 * \param newphase - A std::string containing the phase to use, empty string
+	 * to omit
+	 * \param newpolarity - A std::string containing the polarity to use, empty
+	 * string to omit
+	 * \param newonset - A std::string containing the onset to use, empty string
+	 * to omit
+	 * \param newpicker - A std::string containing the picker to use, empty
+	 * string to omit
+	 * \param newfilterdata -A std::vector<detectionformats::filter> containing
+	 * the filters that were used
+	 * \param newamplitude - A detectionformats::amplitude containing the
+	 * amplitude to use
+	 * \param newbeam - A detectionformats::beam containing the beam to use
+	 */
+	pick(std::string newid, detectionformats::site newsite, double newtime,
+			detectionformats::source newsource, std::string newphase,
+			std::string newpolarity, std::string newonset,
+			std::string newpicker,
+			std::vector<detectionformats::filter> newfilterdata,
+			detectionformats::amplitude newamplitude,
+			detectionformats::beam newbeam);
 
-		/**
-		* \brief pick alternate advanced constructor
-		*
-		* The alternate advanced constructor for the pick class.
-		* Initilizes members to provided values.
-		*
-		* \param newid - A std::string containing the id to use
-		* \param newsite - A detectionformats::site containing the site to use
-		* \param newtime - A double containing the new time to use
-		* \param newsource - A detectionformats::source containing the source to use
-		* \param newphase - A std::string containing the phase to use, empty string to omit
-		* \param newpolarity - A std::string containing the polarity to use, empty string to omit
-		* \param newonset - A std::string containing the onset to use, empty string to omit
-		* \param newpicker - A std::string containing the picker to use, empty string to omit
-		* \param newfilterdata -A std::vector<detectionformats::filter> containing the filters that were used
-		* \param newamplitude - A double containing the amplitude to us
-		*/
-		pick(std::string newid, detectionformats::site newsite, double newtime, detectionformats::source newsource, std::string newphase,
-			     std::string newpolarity, std::string newonset, std::string newpicker, std::vector<detectionformats::filter> newfilterdata,
-			     detectionformats::amplitude newamplitude);
+	/**
+	 * \brief pick alternate advanced constructor
+	 *
+	 * The alternate advanced constructor for the pick class.
+	 * Initilizes members to provided values.
+	 *
+	 * \param newid - A std::string containing the id to use
+	 * \param newsite - A detectionformats::site containing the site to use
+	 * \param newtime - A double containing the new time to use
+	 * \param newsource - A detectionformats::source containing the source to
+	 * use
+	 * \param newphase - A std::string containing the phase to use, empty string
+	 * to omit
+	 * \param newpolarity - A std::string containing the polarity to use, empty
+	 * string to omit
+	 * \param newonset - A std::string containing the onset to use, empty string
+	 * to omit
+	 * \param newpicker - A std::string containing the picker to use, empty
+	 * string to omit
+	 * \param newfilterdata -A std::vector<detectionformats::filter> containing
+	 * the filters that were used
+	 * \param newamplitude - A detectionformats::amplitude containing the the
+	 * amplitude to use
+	 * \param newbeam - A detectionformats::beam containing the beam to use
+	 * \param newassociated - A detectionformats::associated containing the
+	 * associated to use
+	 */
+	pick(std::string newid, detectionformats::site newsite, double newtime,
+			detectionformats::source newsource, std::string newphase,
+			std::string newpolarity, std::string newonset,
+			std::string newpicker,
+			std::vector<detectionformats::filter> newfilterdata,
+			detectionformats::amplitude newamplitude,
+			detectionformats::beam newbeam,
+			detectionformats::associated newassociated);
 
-		/**
-		* \brief pick alternate advanced constructor
-		*
-		* The alternate advanced constructor for the pick class.
-		* Initilizes members to provided values.
-		*
-		* \param newid - A std::string containing the id to use
-		* \param newsite - A detectionformats::site containing the site to use
-		* \param newtime - A double containing the new time to use
-		* \param newsource - A detectionformats::source containing the source to use
-		* \param newphase - A std::string containing the phase to use, empty string to omit
-		* \param newpolarity - A std::string containing the polarity to use, empty string to omit
-		* \param newonset - A std::string containing the onset to use, empty string to omit
-		* \param newpicker - A std::string containing the picker to use, empty string to omit
-		* \param newfilterdata -A std::vector<detectionformats::filter> containing the filters that were used
-		* \param newamplitude - A detectionformats::amplitude containing the the amplitude to us
-		* \param newassociated - A detectionformats::associated containing the associated to use
-		*/
-		pick(std::string newid, detectionformats::site newsite, double newtime, detectionformats::source newsource, std::string newphase,
-			     std::string newpolarity, std::string newonset, std::string newpicker, std::vector<detectionformats::filter> newfilterdata,
-			     detectionformats::amplitude newamplitude, detectionformats::associated newassociated);
+	/**
+	 * \brief pick advanced constructor
+	 *
+	 * The advanced constructor for the pick class.
+	 * Converts the provided object from a json::Object, populating members
+	 * \param jsondocument - A json document.
+	 */
+	pick(rapidjson::Value &json);
 
-		/**
-		* \brief pick advanced constructor
-		*
-		* The advanced constructor for the pick class.
-		* Converts the provided object from a json::Object, populating members
-		* \param jsondocument - A json document.
-		*/
-		pick(rapidjson::Value &json);
+	/**
+	 * \brief pick copy constructor
+	 *
+	 * The copy constructor for the pick class.
+	 * Copys members from provided pick.
+	 *
+	 * \param newpick - A detectionformats::pick to copy from
+	 */
+	pick(const pick &newpick);
 
-		/**
-		* \brief pick copy constructor
-		*
-		* The copy constructor for the pick class.
-		* Copys members from provided pick.
-		*
-		* \param newpick - A detectionformats::pick to copy from
-		*/
-		pick(const pick &newpick);
+	/**
+	 * \brief pick destructor
+	 *
+	 * The destructor for the pick class.
+	 */
+	 ~pick();
 
-		/**
-		* \brief pick destructor
-		*
-		* The destructor for the pick class.
-		*/
-		~pick();
+	/**
+	 * \brief Convert to json object function
+	 *
+	 * Converts the contents of the class to a json object
+	 * \return Returns a json::Object containing the class contents
+	 */
+	virtual rapidjson::Value & tojson(rapidjson::Value &json,
+			rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &allocator)
+					override;
 
-		/**
-		* \brief Convert to json object function
-		*
-		* Converts the contents of the class to a json object
-		* \return Returns a json::Object containing the class contents
-		*/
-		virtual rapidjson::Value & tojson(rapidjson::Value &json, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &allocator) override;
+	/**
+	 * \brief Gets any errors in the class
+	 *
+	 * Gets any formatting errors in the class
+	 * \return Returns a std::vector<std::string> containing the errors
+	 */
+	virtual std::vector<std::string> geterrors() override;
 
-		/**
-		* \brief Gets any errors in the class
-		*
-		* Gets any formatting errors in the class
-		* \return Returns a std::vector<std::string> containing the errors
-		*/
-		virtual std::vector<std::string> geterrors() override;
+	/**
+	 * \brief pick id
+	 *
+	 * A required std::string containing the id of this pick message
+	 */
+	std::string id;
 
-		/**
-		* \brief pick id
-		*
-		* A required std::string containing the id of this pick message
-		*/
-		std::string id;
+	/**
+	 * \brief pick site
+	 *
+	 * A required detectionformats::site containing the site for this pick
+	 * message
+	 */
+	detectionformats::site site;
 
-		/**
-		* \brief pick site
-		*
-		* A required detectionformats::site containing the site for this pick message
-		*/
-		detectionformats::site site;
+	/**
+	 * \brief pick time
+	 *
+	 * A required double containing the time for this pick message
+	 */
+	double time;
 
-		/**
-		* \brief pick time
-		*
-		* A required double containing the time for this pick message
-		*/
-		double time;
+	/**
+	 * \brief pick source
+	 *
+	 * A required detectionformats::source containing the source for this pick
+	 * message
+	 */
+	detectionformats::source source;
 
-		/**
-		* \brief pick source
-		*
-		* A required detectionformats::source containing the source for this pick message
-		*/
-		detectionformats::source source;
+	/**
+	 * \brief pick phase
+	 *
+	 * An optional std::string containing the phase for this pick message
+	 */
+	std::string phase;
 
-		/**
-		* \brief pick phase
-		*
-		* An optional std::string containing the phase for this pick message
-		*/
-		std::string phase;
+	/**
+	 * \brief pick polarity
+	 *
+	 * An optional std::string containing the polarity for this pick message
+	 * valid values are "up" or "down"
+	 */
+	std::string polarity;
 
-		/**
-		* \brief pick polarity
-		*
-		* An optional std::string containing the polarity for this pick message
-		* valid values are "up" or "down"
-		*/
-		std::string polarity;
+	/**
+	 * \brief pick onset
+	 *
+	 * An optional std::string containing the onset for this pick message
+	 * valid values are "impulsive", "emergent", or "questionable"
+	 */
+	std::string onset;
 
-		/**
-		* \brief pick onset
-		*
-		* An optional std::string containing the onset for this pick message
-		* valid values are "impulsive", "emergent", or "questionable"
-		*/
-		std::string onset;
+	/**
+	 * \brief pick picker type
+	 *
+	 * An optional std::string defining the picker that made this pick message
+	 * valid values are "manual", "raypicker", "filterpicker", "earthworm", or
+	 * "other"
+	 */
+	std::string picker;
 
-		/**
-		* \brief pick picker type
-		*
-		* An optional std::string defining the picker that made this pick message
-		* valid values are "manual", "raypicker", "filterpicker", "earthworm", or "other"
-		*/
-		std::string picker;
+	/**
+	 * \brief pick filter data
+	 *
+	 *An optional vector of detectionformats::filter objects containing the
+	 *An filters for this pick message
+	 */
+	std::vector<detectionformats::filter> filterdata;
 
-		/**
-		* \brief pick filter data
-		*
-		*An optional vector of detectionformats::filter objects containing the filters for this pick message
-		*/
-		std::vector<detectionformats::filter> filterdata;
+	/**
+	 * \brief pick amplitude
+	 *
+	 * An optional detectionformats::amplitude containing the amplitude for this
+	 * pick message
+	 */
+	detectionformats::amplitude amplitude;
 
-		/**
-		* \brief pick amplitude
-		*
-		* An optional detectionformats::amplitude containing the amplitude for this pick message
-		*/
-		detectionformats::amplitude amplitude;
+	/**
+	 * \brief pick beam
+	 *
+	 * An optional detectionformats::beam containing the beam information for
+	 * this pick message
+	 */
+	detectionformats::beam beam;
 
-		/**
-		* \brief pick associated
-		*
-		* Optional detectionformats::associated containing the associated information for this pick message
-		*/
-		detectionformats::associated associationinfo;
+	/**
+	 * \brief pick associated
+	 *
+	 * Optional detectionformats::associated containing the associated
+	 * information for this pick message
+	 */
+	detectionformats::associated associationinfo;
 
-	protected:
+protected:
 
-	};
+};
 }
 #endif

--- a/cpp/include/site.h
+++ b/cpp/include/site.h
@@ -1,9 +1,9 @@
 /*****************************************
-* This file is documented for Doxygen.
-* If you modify this file please update
-* the comments so that Doxygen will still
-* be able to work.
-****************************************/
+ * This file is documented for Doxygen.
+ * If you modify this file please update
+ * the comments so that Doxygen will still
+ * be able to work.
+ ****************************************/
 #ifndef DETECTION_SITE_H
 #define DETECTION_SITE_H
 
@@ -12,116 +12,110 @@
 
 #include "base.h"
 
-namespace detectionformats
-{
+namespace detectionformats {
+/**
+ * \brief detectionformats site conversion class
+ *
+ * The detectionformats site class is a conversion class used to create, parse,
+ * and validate site data as part of detection data.
+ *
+ */
+class site: public detectionbase {
+public:
 	/**
-	* \brief detectionformats site conversion class
-	*
-	* The detectionformats site class is a conversion class used to create, parse, and
-	* validate site data as part of detection data.
-	*
-	*/
-	class site : public detectionbase
-	{
-	public:
-		/**
-		* \brief site constructor
-		*
-		* The constructor for the site class.
-		* Initilizes members to null values.
-		*/
-		site();
+	 * \brief site constructor
+	 *
+	 * The constructor for the site class.
+	 * Initilizes members to null values.
+	 */
+	site();
 
-		/**
-		* \brief site advanced constructor
-		*
-		* The advanced constructor for the source class.
-		* Initilizes members to provided values.
-		*
-		* \param newsiteid - A std::string containing the siteid to use
-		* \param newstation - A std::string containing the station to use
-		* \param newchannel - A std::string containing the channel to use
-		* \param newnetwork - A std::string containing the network to use
-		* \param newlocation - A std::string containing the location to use
-		*/
-		site(std::string newsiteid, std::string newstation, std::string newchannel, std::string newnetwork, std::string newlocation);
+	/**
+	 * \brief site advanced constructor
+	 *
+	 * The advanced constructor for the source class.
+	 * Initilizes members to provided values.
+	 *
+	 * \param newstation - A std::string containing the station to use
+	 * \param newchannel - A std::string containing the channel to use
+	 * \param newnetwork - A std::string containing the network to use
+	 * \param newlocation - A std::string containing the location to use
+	 */
+	site(std::string newstation, std::string newchannel, std::string newnetwork,
+			std::string newlocation);
 
-		/**
-		* \brief site advanced constructor
-		*
-		* The advanced constructor for the site class.
-		* Converts the provided object from a json::Object, populating members
-		* \param jsondocument - A json document.
-		*/
-		site(rapidjson::Value &json);
+	/**
+	 * \brief site advanced constructor
+	 *
+	 * The advanced constructor for the site class.
+	 * Converts the provided object from a json::Object, populating members
+	 * \param jsondocument - A json document.
+	 */
+	site(rapidjson::Value &json);
 
-		/**
-		* \brief site copy constructor
-		*
-		* The copy constructor for the site class.
-		* Copies the provided object from a site, populating members
-		* \param newsite - A site.
-		*/
-		site(const site & newsite);
+	/**
+	 * \brief site copy constructor
+	 *
+	 * The copy constructor for the site class.
+	 * Copies the provided object from a site, populating members
+	 * \param newsite - A site.
+	 */
+	site(const site & newsite);
 
-		/**
-		* \brief site destructor
-		*
-		* The destructor for the site class.
-		*/
-		~site();
+	/**
+	 * \brief site destructor
+	 *
+	 * The destructor for the site class.
+	 */
+	~site();
 
-		/**
-		* \brief Convert to json object function
-		*
-		* Converts the contents of the class to a json object
-		* \param jsondocument - a reference to the json document to fill in with the class contents.
-		* \return Returns rapidjson::Value & if successful
-		*/
-		virtual rapidjson::Value & tojson(rapidjson::Value &json, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &allocator) override;
+	/**
+	 * \brief Convert to json object function
+	 *
+	 * Converts the contents of the class to a json object
+	 * \param jsondocument - a reference to the json document to fill in with
+	 * the class contents.
+	 * \return Returns rapidjson::Value & if successful
+	 */
+	virtual rapidjson::Value & tojson(rapidjson::Value &json,
+			rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &allocator)
+					override;
 
-		/**
-		* \brief Gets any errors in the class
-		*
-		* Gets any formatting errors in the class
-		* \return Returns a std::vector<std::string> containing the errors
-		*/
-		virtual std::vector<std::string> geterrors() override;
+	/**
+	 * \brief Gets any errors in the class
+	 *
+	 * Gets any formatting errors in the class
+	 * \return Returns a std::vector<std::string> containing the errors
+	 */
+	virtual std::vector<std::string> geterrors() override;
 
-		/**
-		* \brief site unique identifyer
-		*
-		* A required std::string containing an unique identifier for this site.
-		*/
-		std::string siteid;
+	/**
+	 * \brief site station code
+	 *
+	 * A required std::string containing the station code for this site.
+	 */
+	std::string station;
 
-		/**
-		* \brief site station code
-		*
-		* A required std::string containing the station code for this site.
-		*/
-		std::string station;
+	/**
+	 * \brief site channel code
+	 *
+	 * An optional std::string containing the channel code for this site.
+	 */
+	std::string channel;
 
-		/**
-		* \brief site channel code
-		*
-		* An optional std::string containing the channel code for this site.
-		*/
-		std::string channel;
+	/**
+	 * \brief site network code
+	 *
+	 * A required std::string containing the network code for this site.
+	 */
+	std::string network;
 
-		/**
-		* \brief site network code
-		*
-		* A required std::string containing the network code for this site.
-		*/
-		std::string network;
-
-		/**
-		* \brief site location code
-		*
-		* An optional std::string containing the location code for this site.
-		*/
-		std::string location;
-	};
+	/**
+	 * \brief site location code
+	 *
+	 * An optional std::string containing the location code for this site.
+	 */
+	std::string location;
+};
 }
 #endif

--- a/cpp/src/beam.cpp
+++ b/cpp/src/beam.cpp
@@ -3,176 +3,36 @@
 #include <limits>
 
 // JSON Keys
-#define TYPE_KEY "Type"
-#define ID_KEY "ID"
-#define SITE_KEY "Site"
-#define SOURCE_KEY "Source"
-#define STARTTIME_KEY "StartTime"
-#define ENDTIME_KEY "EndTime"
 #define BACKAZIMUTH_KEY "BackAzimuth"
 #define SLOWNESS_KEY "Slowness"
 #define POWERRATIO_KEY "PowerRatio"
 #define BACKAZIMUTHERROR_KEY "BackAzimuthError"
 #define SLOWNESSERROR_KEY "SlownessError"
 #define POWERRATIOERROR_KEY "PowerRatioError"
-#define ASSOCIATIONINFO_KEY "AssociationInfo"
 
 namespace detectionformats {
 beam::beam() {
-	type = BEAM_TYPE;
-	id = "";
-	site = detectionformats::site();
-	source = detectionformats::source();
-	starttime = std::numeric_limits<double>::quiet_NaN();
-	endtime = std::numeric_limits<double>::quiet_NaN();
 	backazimuth = std::numeric_limits<double>::quiet_NaN();
 	backazimutherror = std::numeric_limits<double>::quiet_NaN();
 	slowness = std::numeric_limits<double>::quiet_NaN();
 	slownesserror = std::numeric_limits<double>::quiet_NaN();
 	powerratio = std::numeric_limits<double>::quiet_NaN();
 	powerratioerror = std::numeric_limits<double>::quiet_NaN();
-	associationinfo = detectionformats::associated();
 }
 
-beam::beam(std::string newid, std::string newsiteid, std::string newstation,
-		std::string newchannel, std::string newnetwork, std::string newlocation,
-		std::string newagencyid, std::string newauthor, double newstarttime,
-		double newendtime, double newbackazimuth, double newbackazimutherror,
+beam::beam(double newbackazimuth, double newbackazimutherror,
 		double newslowness, double newslownesserror, double newpowerratio,
 		double newpowerratioerror) {
-	type = BEAM_TYPE;
-	id = newid;
-	site = detectionformats::site(newsiteid, newstation, newchannel, newnetwork,
-			newlocation);
-	source = detectionformats::source(newagencyid, newauthor);
-	starttime = newstarttime;
-	endtime = newendtime;
 	backazimuth = newbackazimuth;
 	backazimutherror = newbackazimutherror;
 	slowness = newslowness;
 	slownesserror = newslownesserror;
 	powerratio = newpowerratio;
 	powerratioerror = newpowerratioerror;
-	associationinfo = detectionformats::associated();
-}
-
-beam::beam(std::string newid, std::string newsiteid, std::string newstation,
-		std::string newchannel, std::string newnetwork, std::string newlocation,
-		std::string newagencyid, std::string newauthor, double newstarttime,
-		double newendtime, double newbackazimuth, double newbackazimutherror,
-		double newslowness, double newslownesserror, double newpowerratio,
-		double newpowerratioerror, std::string newassociatedphase,
-		double newassociateddistance, double newassociatedazimuth,
-		double newassociatedresidual, double newassociatedsigma) {
-	type = BEAM_TYPE;
-	id = newid;
-	site = detectionformats::site(newsiteid, newstation, newchannel, newnetwork,
-			newlocation);
-	source = detectionformats::source(newagencyid, newauthor);
-	starttime = newstarttime;
-	endtime = newendtime;
-	backazimuth = newbackazimuth;
-	backazimutherror = newbackazimutherror;
-	slowness = newslowness;
-	slownesserror = newslownesserror;
-	powerratio = newpowerratio;
-	powerratioerror = newpowerratioerror;
-	associationinfo = detectionformats::associated(newassociatedphase,
-			newassociateddistance, newassociatedazimuth, newassociatedresidual,
-			newassociatedsigma);
-}
-
-beam::beam(std::string newid, detectionformats::site newsite,
-		detectionformats::source newsource, double newstarttime,
-		double newendtime, double newbackazimuth, double newbackazimutherror,
-		double newslowness, double newslownesserror, double newpowerratio,
-		double newpowerratioerror) {
-	type = BEAM_TYPE;
-	id = newid;
-	site = newsite;
-	source = newsource;
-	starttime = newstarttime;
-	endtime = newendtime;
-	backazimuth = newbackazimuth;
-	backazimutherror = newbackazimutherror;
-	slowness = newslowness;
-	slownesserror = newslownesserror;
-	powerratio = newpowerratio;
-	powerratioerror = newpowerratioerror;
-	associationinfo = detectionformats::associated();
-}
-
-beam::beam(std::string newid, detectionformats::site newsite,
-		detectionformats::source newsource, double newstarttime,
-		double newendtime, double newbackazimuth, double newbackazimutherror,
-		double newslowness, double newslownesserror, double newpowerratio,
-		double newpowerratioerror, detectionformats::associated newassociated) {
-	type = BEAM_TYPE;
-	id = newid;
-	site = newsite;
-	source = newsource;
-	starttime = newstarttime;
-	endtime = newendtime;
-	backazimuth = newbackazimuth;
-	backazimutherror = newbackazimutherror;
-	slowness = newslowness;
-	slownesserror = newslownesserror;
-	powerratio = newpowerratio;
-	powerratioerror = newpowerratioerror;
-	associationinfo = newassociated;
 }
 
 beam::beam(rapidjson::Value &json) {
 	// required values
-	// type
-	if ((json.HasMember(TYPE_KEY) == true)
-			&& (json[TYPE_KEY].IsString() == true))
-		type = std::string(json[TYPE_KEY].GetString(),
-				json[TYPE_KEY].GetStringLength());
-	else
-		type = "";
-
-	// id
-	if ((json.HasMember(ID_KEY) == true) && (json[ID_KEY].IsString() == true))
-		id = std::string(json[ID_KEY].GetString(),
-				json[ID_KEY].GetStringLength());
-	else
-		id = "";
-
-	// site
-	if ((json.HasMember(SITE_KEY) == true)
-			&& (json[SITE_KEY].IsObject() == true)) {
-		rapidjson::Value & sitevalue = json["Site"];
-		site = detectionformats::site(sitevalue);
-	} else
-		site = detectionformats::site();
-
-	// source
-	if ((json.HasMember(SOURCE_KEY) == true)
-			&& (json[SOURCE_KEY].IsObject() == true)) {
-		rapidjson::Value & sourcevalue = json[SOURCE_KEY];
-		source = detectionformats::source(sourcevalue);
-	} else
-		source = detectionformats::source();
-
-	// starttime
-	if ((json.HasMember(STARTTIME_KEY) == true)
-			&& (json[STARTTIME_KEY].IsString() == true))
-		starttime = detectionformats::ConvertISO8601ToEpochTime(
-				std::string(json[STARTTIME_KEY].GetString(),
-						json[STARTTIME_KEY].GetStringLength()));
-	else
-		starttime = std::numeric_limits<double>::quiet_NaN();
-
-	// endtime
-	if ((json.HasMember(ENDTIME_KEY) == true)
-			&& (json[ENDTIME_KEY].IsString() == true))
-		endtime = detectionformats::ConvertISO8601ToEpochTime(
-				std::string(json[ENDTIME_KEY].GetString(),
-						json[ENDTIME_KEY].GetStringLength()));
-	else
-		endtime = std::numeric_limits<double>::quiet_NaN();
-
 	// backazimuth
 	if ((json.HasMember(BACKAZIMUTH_KEY) == true)
 			&& (json[BACKAZIMUTH_KEY].IsNumber() == true)
@@ -189,7 +49,8 @@ beam::beam(rapidjson::Value &json) {
 	else
 		slowness = std::numeric_limits<double>::quiet_NaN();
 
-	// slowness
+	// optional values
+	// power ratio
 	if ((json.HasMember(POWERRATIO_KEY) == true)
 			&& (json[POWERRATIO_KEY].IsNumber() == true)
 			&& (json[POWERRATIO_KEY].IsDouble() == true))
@@ -197,7 +58,6 @@ beam::beam(rapidjson::Value &json) {
 	else
 		powerratio = std::numeric_limits<double>::quiet_NaN();
 
-	// optional values
 	// backazimutherror
 	if ((json.HasMember(BACKAZIMUTHERROR_KEY) == true)
 			&& (json[BACKAZIMUTHERROR_KEY].IsNumber() == true)
@@ -221,30 +81,16 @@ beam::beam(rapidjson::Value &json) {
 		powerratioerror = json[POWERRATIOERROR_KEY].GetDouble();
 	else
 		powerratioerror = std::numeric_limits<double>::quiet_NaN();
-
-	// associated
-	if ((json.HasMember(ASSOCIATIONINFO_KEY) == true)
-			&& (json[ASSOCIATIONINFO_KEY].IsObject() == true)) {
-		rapidjson::Value & associatedvalue = json[ASSOCIATIONINFO_KEY];
-		associationinfo = detectionformats::associated(associatedvalue);
-	} else
-		associationinfo = detectionformats::associated();
 }
 
 beam::beam(const beam &newbeam) {
-	type = BEAM_TYPE;
-	id = newbeam.id;
-	site = newbeam.site;
-	source = newbeam.source;
-	starttime = newbeam.starttime;
-	endtime = newbeam.endtime;
+
 	backazimuth = newbeam.backazimuth;
 	backazimutherror = newbeam.backazimutherror;
 	slowness = newbeam.slowness;
 	slownesserror = newbeam.slownesserror;
 	powerratio = newbeam.powerratio;
 	powerratioerror = newbeam.powerratioerror;
-	associationinfo = newbeam.associationinfo;
 }
 
 beam::~beam() {
@@ -255,48 +101,6 @@ rapidjson::Value & beam::tojson(rapidjson::Value &json,
 	json.SetObject();
 
 	// required values
-	// type
-	rapidjson::Value typevalue;
-	typevalue.SetString(rapidjson::StringRef(type.c_str()), allocator);
-	json.AddMember(TYPE_KEY, typevalue, allocator);
-
-	// id
-	if (id != "") {
-		rapidjson::Value idvalue;
-		idvalue.SetString(rapidjson::StringRef(id.c_str()), allocator);
-		json.AddMember(ID_KEY, idvalue, allocator);
-	}
-
-	// site
-	rapidjson::Value sitevalue(rapidjson::kObjectType);
-	site.tojson(sitevalue, allocator);
-	json.AddMember(SITE_KEY, sitevalue, allocator);
-
-	// source
-	rapidjson::Value sourcevalue(rapidjson::kObjectType);
-	source.tojson(sourcevalue, allocator);
-	json.AddMember(SOURCE_KEY, sourcevalue, allocator);
-
-	// starttime
-	if (std::isnan(starttime) != true) {
-		std::string timestring = detectionformats::ConvertEpochTimeToISO8601(
-				starttime);
-		rapidjson::Value timevalue;
-		timevalue.SetString(rapidjson::StringRef(timestring.c_str()),
-				allocator);
-		json.AddMember(STARTTIME_KEY, timevalue, allocator);
-	}
-
-	// endtime
-	if (std::isnan(endtime) != true) {
-		std::string timestring = detectionformats::ConvertEpochTimeToISO8601(
-				endtime);
-		rapidjson::Value timevalue;
-		timevalue.SetString(rapidjson::StringRef(timestring.c_str()),
-				allocator);
-		json.AddMember(ENDTIME_KEY, timevalue, allocator);
-	}
-
 	// backazimuth
 	if (std::isnan(backazimuth) != true)
 		json.AddMember(BACKAZIMUTH_KEY, backazimuth, allocator);
@@ -305,11 +109,11 @@ rapidjson::Value & beam::tojson(rapidjson::Value &json,
 	if (std::isnan(slowness) != true)
 		json.AddMember(SLOWNESS_KEY, slowness, allocator);
 
+	// optional values
 	// powerratio
 	if (std::isnan(powerratio) != true)
 		json.AddMember(POWERRATIO_KEY, powerratio, allocator);
 
-	// optional values
 	// backazimutherror
 	if (std::isnan(backazimutherror) != true)
 		json.AddMember(BACKAZIMUTHERROR_KEY, backazimutherror, allocator);
@@ -322,74 +126,13 @@ rapidjson::Value & beam::tojson(rapidjson::Value &json,
 	if (std::isnan(powerratioerror) != true)
 		json.AddMember(POWERRATIOERROR_KEY, powerratioerror, allocator);
 
-	// associated
-	if (associationinfo.isempty() == false) {
-		rapidjson::Value associatedvalue(rapidjson::kObjectType);
-		associationinfo.tojson(associatedvalue, allocator);
-		json.AddMember(ASSOCIATIONINFO_KEY, associatedvalue, allocator);
-	}
-
 	return (json);
 }
 
 std::vector<std::string> beam::geterrors() {
-	std::vector < std::string > errorlist;
+	std::vector<std::string> errorlist;
 
 	// check required data
-	// Type
-	if (type != BEAM_TYPE) {
-		// wrong type
-		errorlist.push_back("Non-beam type in beam class.");
-	}
-
-	// id
-	if (id == "") {
-		// empty id
-		errorlist.push_back("Empty ID in beam class.");
-	}
-
-	// site
-	if (site.isvalid() != true) {
-		// site not found
-		errorlist.push_back("Site object did not validate in beam class.");
-	}
-
-	// source
-	if (source.isvalid() != true) {
-		// bad source
-		errorlist.push_back("Source object did not validate in beam class.");
-	}
-
-	// starttime
-	if (std::isnan(starttime) == true) {
-		errorlist.push_back("Start Time is missing in beam class.");
-	} else {
-		try {
-			if (detectionformats::IsStringISO8601(
-					detectionformats::ConvertEpochTimeToISO8601(starttime))
-					== false) {
-				errorlist.push_back("Start Time did not validate in beam class.");
-			}
-		} catch (const std::exception & e) {
-			errorlist.push_back(std::string(e.what()));
-		}
-	}
-
-	// endtime
-	if (std::isnan(endtime) == true) {
-		errorlist.push_back("End Time is missing in beam class.");
-	} else {
-		try {
-			if (detectionformats::IsStringISO8601(
-					detectionformats::ConvertEpochTimeToISO8601(endtime))
-					== false) {
-				errorlist.push_back("End Time did not validate in beam class.");
-			}
-		} catch (const std::exception & e) {
-			errorlist.push_back(std::string(e.what()));
-		}
-	}
-
 	// backazimuth
 	if (std::isnan(backazimuth) == true) {
 		// backazimuth not found
@@ -408,16 +151,14 @@ std::vector<std::string> beam::geterrors() {
 		errorlist.push_back("Invalid Slowness in beam class.");
 	}
 
+	// optional data
 	// powerratio
-	if (std::isnan(powerratio) == true) {
-		// powerratio not found
-		errorlist.push_back("No PowerRatio in beam class.");
-	}
-	if (powerratio < 0) {
-		errorlist.push_back("Invalid PowerRatio in beam class.");
+	if (std::isnan(powerratio) != true) {
+		if (powerratio < 0) {
+			errorlist.push_back("Invalid PowerRatio in beam class.");
+		}
 	}
 
-	// optional data
 	// backazimutherror
 	if (std::isnan(backazimutherror) != true) {
 		if (backazimutherror < 0) {
@@ -437,17 +178,26 @@ std::vector<std::string> beam::geterrors() {
 		}
 	}
 
-	// associated
-	if (associationinfo.isempty() == false) {
-		if (associationinfo.isvalid() != true) {
-			// site not found
-			errorlist.push_back(
-					"AssociationInfo object did not validate in beam class.");
-		}
-	}
-
 	// return the list of errors
 	return (errorlist);
+}
+
+bool beam::isempty()
+{
+	if (std::isnan(backazimuth) != true)
+		return(false);
+	if (std::isnan(slowness) != true)
+		return(false);
+	if (std::isnan(powerratio) != true)
+		return(false);
+	if (std::isnan(backazimutherror) != true)
+		return(false);
+	if (std::isnan(slownesserror) != true)
+		return(false);
+	if (std::isnan(powerratioerror) != true)
+		return(false);
+
+	return (true);
 }
 
 }

--- a/cpp/src/correlation.cpp
+++ b/cpp/src/correlation.cpp
@@ -38,18 +38,18 @@ correlation::correlation() {
 	associationinfo = detectionformats::associated();
 }
 
-correlation::correlation(std::string newid, std::string newsiteid,
-		std::string newstation, std::string newchannel, std::string newnetwork,
-		std::string newlocation, std::string newagencyid, std::string newauthor,
-		std::string newphase, double newtime, double newcorrelation,
-		double newlatitude, double newlongitude, double neworigintime,
-		double newdepth, double newlatitudeerror, double newlongitudeerror,
-		double newtimeerror, double newdeptherror, std::string neweventtype,
-		double newmagnitude, double newsnr, double newzscore,
-		double newdetectionthreshold, std::string newthresholdtype) {
+correlation::correlation(std::string newid, std::string newstation,
+		std::string newchannel, std::string newnetwork, std::string newlocation,
+		std::string newagencyid, std::string newauthor, std::string newphase,
+		double newtime, double newcorrelation, double newlatitude,
+		double newlongitude, double neworigintime, double newdepth,
+		double newlatitudeerror, double newlongitudeerror, double newtimeerror,
+		double newdeptherror, std::string neweventtype, double newmagnitude,
+		double newsnr, double newzscore, double newdetectionthreshold,
+		std::string newthresholdtype) {
 	type = CORRELATION_TYPE;
 	id = newid;
-	site = detectionformats::site(newsiteid, newstation, newchannel, newnetwork,
+	site = detectionformats::site(newstation, newchannel, newnetwork,
 			newlocation);
 	source = detectionformats::source(newagencyid, newauthor);
 	phase = newphase;
@@ -67,21 +67,20 @@ correlation::correlation(std::string newid, std::string newsiteid,
 	associationinfo = detectionformats::associated();
 }
 
-correlation::correlation(std::string newid, std::string newsiteid,
-		std::string newstation, std::string newchannel, std::string newnetwork,
-		std::string newlocation, std::string newagencyid, std::string newauthor,
-		std::string newphase, double newtime, double newcorrelation,
-		double newlatitude, double newlongitude, double neworigintime,
-		double newdepth, double newlatitudeerror, double newlongitudeerror,
-		double newtimeerror, double newdeptherror, std::string neweventtype,
-		double newmagnitude, double newsnr, double newzscore,
-		double newdetectionthreshold, std::string newthresholdtype,
-		std::string newassociatedphase, double newassociateddistance,
-		double newassociatedazimuth, double newassociatedresidual,
-		double newassociatedsigma) {
+correlation::correlation(std::string newid, std::string newstation,
+		std::string newchannel, std::string newnetwork, std::string newlocation,
+		std::string newagencyid, std::string newauthor, std::string newphase,
+		double newtime, double newcorrelation, double newlatitude,
+		double newlongitude, double neworigintime, double newdepth,
+		double newlatitudeerror, double newlongitudeerror, double newtimeerror,
+		double newdeptherror, std::string neweventtype, double newmagnitude,
+		double newsnr, double newzscore, double newdetectionthreshold,
+		std::string newthresholdtype, std::string newassociatedphase,
+		double newassociateddistance, double newassociatedazimuth,
+		double newassociatedresidual, double newassociatedsigma) {
 	type = CORRELATION_TYPE;
 	id = newid;
-	site = detectionformats::site(newsiteid, newstation, newchannel, newnetwork,
+	site = detectionformats::site(newstation, newchannel, newnetwork,
 			newlocation);
 	source = detectionformats::source(newagencyid, newauthor);
 	phase = newphase;

--- a/cpp/src/detection.cpp
+++ b/cpp/src/detection.cpp
@@ -28,7 +28,6 @@ detection::detection() {
 	rms = std::numeric_limits<double>::quiet_NaN();
 	gap = std::numeric_limits<double>::quiet_NaN();
 	pickdata.clear();
-	beamdata.clear();
 	correlationdata.clear();
 }
 
@@ -39,7 +38,6 @@ detection::detection(std::string newid, std::string newagencyid,
 		std::string newdetectiontype, std::string neweventtype, double newbayes,
 		double newminimumdistance, double newrms, double newgap,
 		std::vector<detectionformats::pick> newpickdata,
-		std::vector<detectionformats::beam> newbeamdata,
 		std::vector<detectionformats::correlation> newcorrelationdata) {
 	type = DETECTION_TYPE;
 	id = newid;
@@ -60,11 +58,6 @@ detection::detection(std::string newid, std::string newagencyid,
 		pickdata.push_back(newpickdata[i]);
 	}
 
-	beamdata.clear();
-	for (int i = 0; i < (int) newbeamdata.size(); i++) {
-		beamdata.push_back(newbeamdata[i]);
-	}
-
 	correlationdata.clear();
 	for (int i = 0; i < (int) newcorrelationdata.size(); i++) {
 		correlationdata.push_back(newcorrelationdata[i]);
@@ -72,11 +65,10 @@ detection::detection(std::string newid, std::string newagencyid,
 }
 
 detection::detection(std::string newid, detectionformats::source newsource,
-		detectionformats::hypocenter newhypocenter, std::string newdetectiontype,
-		std::string neweventtype, double newbayes, double newminimumdistance,
-		double newrms, double newgap,
+		detectionformats::hypocenter newhypocenter,
+		std::string newdetectiontype, std::string neweventtype, double newbayes,
+		double newminimumdistance, double newrms, double newgap,
 		std::vector<detectionformats::pick> newpickdata,
-		std::vector<detectionformats::beam> newbeamdata,
 		std::vector<detectionformats::correlation> newcorrelationdata) {
 	type = DETECTION_TYPE;
 	id = newid;
@@ -93,11 +85,6 @@ detection::detection(std::string newid, detectionformats::source newsource,
 	pickdata.clear();
 	for (int i = 0; i < (int) newpickdata.size(); i++) {
 		pickdata.push_back(newpickdata[i]);
-	}
-
-	beamdata.clear();
-	for (int i = 0; i < (int) newbeamdata.size(); i++) {
-		beamdata.push_back(newbeamdata[i]);
 	}
 
 	correlationdata.clear();
@@ -188,7 +175,6 @@ detection::detection(rapidjson::Value &json) {
 
 	// data
 	pickdata.clear();
-	beamdata.clear();
 	correlationdata.clear();
 
 	if ((json.HasMember(DATA_KEY) == true)
@@ -209,11 +195,6 @@ detection::detection(rapidjson::Value &json) {
 
 				// add to vector
 				pickdata.push_back(newpickdata);
-			} else if (typestring == BEAM_TYPE) {
-				detectionformats::beam newbeamdata(datavalue);
-
-				// add to vector
-				beamdata.push_back(newbeamdata);
 			} else if (typestring == CORRELATION_TYPE) {
 				detectionformats::correlation newcorrelationdata(datavalue);
 
@@ -243,11 +224,6 @@ detection::detection(const detection & newdetection) {
 		pickdata.push_back(newdetection.pickdata[i]);
 	}
 
-	beamdata.clear();
-	for (int i = 0; i < (int) newdetection.beamdata.size(); i++) {
-		beamdata.push_back(newdetection.beamdata[i]);
-	}
-
 	correlationdata.clear();
 	for (int i = 0; i < (int) newdetection.correlationdata.size(); i++) {
 		correlationdata.push_back(newdetection.correlationdata[i]);
@@ -256,7 +232,6 @@ detection::detection(const detection & newdetection) {
 
 detection::~detection() {
 	pickdata.clear();
-	beamdata.clear();
 	correlationdata.clear();
 }
 
@@ -291,8 +266,8 @@ rapidjson::Value & detection::tojson(rapidjson::Value &json,
 	// detectiontype
 	if (detectiontype != "") {
 		rapidjson::Value detectiontypevalue;
-		detectiontypevalue.SetString(rapidjson::StringRef(detectiontype.c_str()),
-				allocator);
+		detectiontypevalue.SetString(
+				rapidjson::StringRef(detectiontype.c_str()), allocator);
 		json.AddMember(DETECTIONTYPE_KEY, detectiontypevalue, allocator);
 	}
 
@@ -333,15 +308,6 @@ rapidjson::Value & detection::tojson(rapidjson::Value &json,
 		}
 	}
 
-	// beamdata
-	if (beamdata.size() > 0) {
-		for (int i = 0; i < (int) beamdata.size(); i++) {
-			rapidjson::Value beamvalue(rapidjson::kObjectType);
-			beamdata[i].tojson(beamvalue, allocator);
-			dataarray.PushBack(beamvalue, allocator);
-		}
-	}
-
 	// correlationdata
 	if (correlationdata.size() > 0) {
 		for (int i = 0; i < (int) correlationdata.size(); i++) {
@@ -379,7 +345,8 @@ std::vector<std::string> detection::geterrors() {
 	// source
 	if (source.isvalid() != true) {
 		// bad source
-		errorlist.push_back("Source object did not validate in detection class.");
+		errorlist.push_back(
+				"Source object did not validate in detection class.");
 	}
 
 	// hypocenter
@@ -395,7 +362,8 @@ std::vector<std::string> detection::geterrors() {
 		bool match = false;
 		// check all the valid types to see if this string matches
 		for (int i = detectionformats::detectiontypeindex::newdetection;
-				i < detectionformats::detectiontypeindex::detectiontypecount; i++) {
+				i < detectionformats::detectiontypeindex::detectiontypecount;
+				i++) {
 			if (detectiontype == detectionformats::detectiontypevalues[i]) {
 				match = true;
 				break;
@@ -459,16 +427,6 @@ std::vector<std::string> detection::geterrors() {
 			if (pickdata[i].isvalid() != true) {
 				// bad source
 				errorlist.push_back("Invalid pick in detection class.");
-			}
-		}
-	}
-
-	// beamdata
-	if (beamdata.size() > 0) {
-		for (int i = 0; i < (int) beamdata.size(); i++) {
-			if (beamdata[i].isvalid() != true) {
-				// bad source
-				errorlist.push_back("Invalid beam in detection class.");
 			}
 		}
 	}

--- a/cpp/src/pick.cpp
+++ b/cpp/src/pick.cpp
@@ -14,505 +14,544 @@
 #define PICKER_KEY "Picker"
 #define FILTER_KEY "Filter"
 #define AMPLITUDE_KEY "Amplitude"
+#define BEAM_KEY "Beam"
 #define ASSOCIATIONINFO_KEY "AssociationInfo"
 
-namespace detectionformats
-{
-	pick::pick()
-	{
-		type = PICK_TYPE;
+namespace detectionformats {
+pick::pick() {
+	type = PICK_TYPE;
+	id = "";
+	site = detectionformats::site();
+	time = std::numeric_limits<double>::quiet_NaN();
+	source = detectionformats::source();
+	phase = "";
+	polarity = "";
+	onset = "";
+	picker = "";
+	filterdata.clear();
+	amplitude = detectionformats::amplitude();
+	beam = detectionformats::beam();
+	associationinfo = detectionformats::associated();
+}
+
+pick::pick(std::string newid, std::string newstation, std::string newchannel,
+		std::string newnetwork, std::string newlocation, double newtime,
+		std::string newagencyid, std::string newauthor, std::string newphase,
+		std::string newpolarity, std::string newonset, std::string newpicker,
+		double newhighpass, double newlowpass, double newamplitude,
+		double newperiod, double newsnr, double newbackazimuth,
+		double newbackazimutherror, double newslowness, double newslownesserror,
+		double newpowerratio, double newpowerratioerror,
+		std::string newassociatedphase, double newassociateddistance,
+		double newassociatedazimuth, double newassociatedresidual,
+		double newassociatedsigma) {
+	type = PICK_TYPE;
+	id = newid;
+	site = detectionformats::site(newstation, newchannel, newnetwork,
+			newlocation);
+	time = newtime;
+	source = detectionformats::source(newagencyid, newauthor);
+	phase = newphase;
+	polarity = newpolarity;
+	onset = newonset;
+	picker = newpicker;
+
+	filterdata.clear();
+	filterdata.push_back(detectionformats::filter(newhighpass, newlowpass));
+
+	amplitude = detectionformats::amplitude(newamplitude, newperiod, newsnr);
+
+	beam = detectionformats::beam(newbackazimuth, newbackazimutherror,
+			newslowness, newslownesserror, newpowerratio, newpowerratioerror);
+
+	associationinfo = detectionformats::associated(newassociatedphase,
+			newassociateddistance, newassociatedazimuth, newassociatedresidual,
+			newassociatedsigma);
+}
+
+pick::pick(std::string newid, std::string newstation,
+		std::string newchannel, std::string newnetwork, std::string newlocation,
+		double newtime, std::string newagencyid, std::string newauthor,
+		std::string newphase, std::string newpolarity, std::string newonset,
+		std::string newpicker, double newhighpass, double newlowpass,
+		double newamplitude, double newperiod, double newsnr,
+		double newbackazimuth, double newbackazimutherror, double newslowness,
+		double newslownesserror, double newpowerratio,
+		double newpowerratioerror) {
+	type = PICK_TYPE;
+	id = newid;
+	site = detectionformats::site(newstation, newchannel, newnetwork,
+			newlocation);
+	time = newtime;
+	source = detectionformats::source(newagencyid, newauthor);
+	phase = newphase;
+	polarity = newpolarity;
+	onset = newonset;
+	picker = newpicker;
+
+	filterdata.clear();
+	filterdata.push_back(detectionformats::filter(newhighpass, newlowpass));
+
+	amplitude = detectionformats::amplitude(newamplitude, newperiod, newsnr);
+
+	beam = detectionformats::beam(newbackazimuth, newbackazimutherror,
+			newslowness, newslownesserror, newpowerratio, newpowerratioerror);
+
+	associationinfo = detectionformats::associated();
+}
+
+pick::pick(std::string newid, detectionformats::site newsite, double newtime,
+		detectionformats::source newsource, std::string newphase,
+		std::string newpolarity, std::string newonset, std::string newpicker,
+		std::vector<detectionformats::filter> newfilterdata,
+		detectionformats::amplitude newamplitude,
+		detectionformats::beam newbeam) {
+	type = PICK_TYPE;
+	id = newid;
+	pick::site = newsite;
+	time = newtime;
+	pick::source = newsource;
+	phase = newphase;
+	polarity = newpolarity;
+	onset = newonset;
+	picker = newpicker;
+
+	filterdata.clear();
+	for (int i = 0; i < (int) newfilterdata.size(); i++) {
+		filterdata.push_back(newfilterdata[i]);
+	}
+
+	pick::amplitude = newamplitude;
+
+	pick::beam = newbeam;
+
+	pick::associationinfo = detectionformats::associated();
+}
+
+pick::pick(std::string newid, detectionformats::site newsite, double newtime,
+		detectionformats::source newsource, std::string newphase,
+		std::string newpolarity, std::string newonset, std::string newpicker,
+		std::vector<detectionformats::filter> newfilterdata,
+		detectionformats::amplitude newamplitude,
+		detectionformats::beam newbeam,
+		detectionformats::associated newassociated) {
+	type = PICK_TYPE;
+	id = newid;
+	site = newsite;
+	time = newtime;
+	source = newsource;
+	phase = newphase;
+	polarity = newpolarity;
+	onset = newonset;
+	picker = newpicker;
+
+	filterdata.clear();
+	for (int i = 0; i < (int) newfilterdata.size(); i++) {
+		filterdata.push_back(newfilterdata[i]);
+	}
+
+	amplitude = newamplitude;
+
+	pick::beam = newbeam;
+
+	associationinfo = newassociated;
+}
+
+pick::pick(rapidjson::Value &json) {
+	// required values
+	// type
+	if ((json.HasMember(TYPE_KEY) == true)
+			&& (json[TYPE_KEY].IsString() == true))
+		type = std::string(json[TYPE_KEY].GetString(),
+				json[TYPE_KEY].GetStringLength());
+	else
+		type = "";
+
+	// id
+	if ((json.HasMember(ID_KEY) == true) && (json[ID_KEY].IsString() == true))
+		id = std::string(json[ID_KEY].GetString(),
+				json[ID_KEY].GetStringLength());
+	else
 		id = "";
+
+	// site
+	if ((json.HasMember(SITE_KEY) == true)
+			&& (json[SITE_KEY].IsObject() == true)) {
+		rapidjson::Value & sitevalue = json["Site"];
+		site = detectionformats::site(sitevalue);
+	} else
 		site = detectionformats::site();
-		time = std::numeric_limits<double>::quiet_NaN();
+
+	// source
+	if ((json.HasMember(SOURCE_KEY) == true)
+			&& (json[SOURCE_KEY].IsObject() == true)) {
+		rapidjson::Value & sourcevalue = json[SOURCE_KEY];
+		source = detectionformats::source(sourcevalue);
+	} else
 		source = detectionformats::source();
+
+	// time
+	if ((json.HasMember(TIME_KEY) == true)
+			&& (json[TIME_KEY].IsString() == true))
+		time = detectionformats::ConvertISO8601ToEpochTime(
+				std::string(json[TIME_KEY].GetString(),
+						json[TIME_KEY].GetStringLength()));
+	else
+		time = std::numeric_limits<double>::quiet_NaN();
+
+	// optional values
+	// phase
+	if ((json.HasMember(PHASE_KEY) == true)
+			&& (json[PHASE_KEY].IsString() == true))
+		phase = std::string(json[PHASE_KEY].GetString(),
+				json[PHASE_KEY].GetStringLength());
+	else
 		phase = "";
+
+	// polarity
+	if ((json.HasMember(POLARITY_KEY) == true)
+			&& (json[POLARITY_KEY].IsString() == true))
+		polarity = std::string(json[POLARITY_KEY].GetString(),
+				json[POLARITY_KEY].GetStringLength());
+	else
 		polarity = "";
+
+	// onset
+	if ((json.HasMember(ONSET_KEY) == true)
+			&& (json[ONSET_KEY].IsString() == true))
+		onset = std::string(json[ONSET_KEY].GetString(),
+				json[ONSET_KEY].GetStringLength());
+	else
 		onset = "";
+
+	// picker
+	if ((json.HasMember(PICKER_KEY) == true)
+			&& (json[PICKER_KEY].IsString() == true))
+		picker = std::string(json[PICKER_KEY].GetString(),
+				json[PICKER_KEY].GetStringLength());
+	else
 		picker = "";
-		filterdata.clear();
+
+	// filter
+	filterdata.clear();
+	if ((json.HasMember(FILTER_KEY) == true)
+			&& (json[FILTER_KEY].IsArray() == true)) {
+		rapidjson::Value dataarray;
+		dataarray = json[FILTER_KEY].GetArray();
+
+		for (rapidjson::SizeType i = 0; i < dataarray.Size(); i++) {
+			// parse
+			rapidjson::Value & datavalue = dataarray[i];
+			detectionformats::filter newfilter(datavalue);
+
+			// add to vector
+			filterdata.push_back(newfilter);
+		}
+	}
+
+	// amplitude
+	if ((json.HasMember(AMPLITUDE_KEY) == true)
+			&& (json[AMPLITUDE_KEY].IsObject() == true)) {
+		rapidjson::Value & amplitudevalue = json[AMPLITUDE_KEY];
+		amplitude = detectionformats::amplitude(amplitudevalue);
+	} else
 		amplitude = detectionformats::amplitude();
+
+	// beam
+	if ((json.HasMember(BEAM_KEY) == true)
+			&& (json[BEAM_KEY].IsObject() == true)) {
+		rapidjson::Value & beamvalue = json[BEAM_KEY];
+		beam = detectionformats::beam(beamvalue);
+	} else
+		beam = detectionformats::beam();
+
+	// associated
+	if ((json.HasMember(ASSOCIATIONINFO_KEY) == true)
+			&& (json[ASSOCIATIONINFO_KEY].IsObject() == true)) {
+		rapidjson::Value & associatedvalue = json[ASSOCIATIONINFO_KEY];
+		associationinfo = detectionformats::associated(associatedvalue);
+	} else
 		associationinfo = detectionformats::associated();
+}
+
+pick::pick(const pick &newpick) {
+	type = PICK_TYPE;
+	id = newpick.id;
+	site = newpick.site;
+	time = newpick.time;
+	source = newpick.source;
+	phase = newpick.phase;
+	polarity = newpick.polarity;
+	onset = newpick.onset;
+	picker = newpick.picker;
+
+	filterdata.clear();
+	for (int i = 0; i < (int) newpick.filterdata.size(); i++) {
+		filterdata.push_back(newpick.filterdata[i]);
 	}
 
-	pick::pick(std::string newid, std::string newsiteid, std::string newstation, std::string newchannel, std::string newnetwork, std::string newlocation, double newtime, std::string newagencyid, std::string newauthor, std::string newphase, std::string newpolarity, std::string newonset, std::string newpicker, double newhighpass, double newlowpass, double newamplitude, double newperiod, double newsnr, std::string newassociatedphase, double newassociateddistance, double newassociatedazimuth, double newassociatedresidual, double newassociatedsigma)
-	{
-		type = PICK_TYPE;
-		id = newid;
-		site = detectionformats::site(newsiteid, newstation, newchannel, newnetwork, newlocation);
-		time = newtime;
-		source = detectionformats::source(newagencyid, newauthor);
-		phase = newphase;
-		polarity = newpolarity;
-		onset = newonset;
-		picker = newpicker;
+	amplitude = newpick.amplitude;
 
-		filterdata.clear();
-		filterdata.push_back(detectionformats::filter(newhighpass, newlowpass));
+	beam = newpick.beam;
 
-		amplitude = detectionformats::amplitude(newamplitude, newperiod, newsnr);
-		associationinfo = detectionformats::associated(newassociatedphase, newassociateddistance, newassociatedazimuth, newassociatedresidual, newassociatedsigma);
+	associationinfo = newpick.associationinfo;
+}
+
+pick::~pick() {
+}
+
+rapidjson::Value & pick::tojson(rapidjson::Value &json,
+		rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &allocator) {
+	json.SetObject();
+
+	// required values
+	// type
+	rapidjson::Value typevalue;
+	typevalue.SetString(rapidjson::StringRef(type.c_str()), allocator);
+	json.AddMember(TYPE_KEY, typevalue, allocator);
+
+	// id
+	if (id != "") {
+		rapidjson::Value idvalue;
+		idvalue.SetString(rapidjson::StringRef(id.c_str()), allocator);
+		json.AddMember(ID_KEY, idvalue, allocator);
 	}
 
-	pick::pick(std::string newid, std::string newsiteid, std::string newstation, std::string newchannel, std::string newnetwork, std::string newlocation, double newtime, std::string newagencyid, std::string newauthor, std::string newphase, std::string newpolarity, std::string newonset, std::string newpicker, double newhighpass, double newlowpass, double newamplitude, double newperiod, double newsnr)
-	{
-		type = PICK_TYPE;
-		id = newid;
-		site = detectionformats::site(newsiteid, newstation, newchannel, newnetwork, newlocation);
-		time = newtime;
-		source = detectionformats::source(newagencyid, newauthor);
-		phase = newphase;
-		polarity = newpolarity;
-		onset = newonset;
-		picker = newpicker;
+	// site
+	rapidjson::Value sitevalue(rapidjson::kObjectType);
+	site.tojson(sitevalue, allocator);
+	json.AddMember(SITE_KEY, sitevalue, allocator);
 
-		filterdata.clear();
-		filterdata.push_back(detectionformats::filter(newhighpass, newlowpass));
+	// source
+	rapidjson::Value sourcevalue(rapidjson::kObjectType);
+	source.tojson(sourcevalue, allocator);
+	json.AddMember(SOURCE_KEY, sourcevalue, allocator);
 
-		amplitude = detectionformats::amplitude(newamplitude, newperiod, newsnr);
-		associationinfo = detectionformats::associated();
+	// time
+	if (std::isnan(time) != true) {
+		std::string timestring = detectionformats::ConvertEpochTimeToISO8601(
+				time);
+		rapidjson::Value timevalue;
+		timevalue.SetString(rapidjson::StringRef(timestring.c_str()),
+				allocator);
+		json.AddMember(TIME_KEY, timevalue, allocator);
 	}
 
-	pick::pick(std::string newid, detectionformats::site newsite, double newtime, detectionformats::source newsource, std::string newphase, std::string newpolarity, std::string newonset, std::string newpicker, std::vector<detectionformats::filter> newfilterdata, detectionformats::amplitude newamplitude)
-	{
-		type = PICK_TYPE;
-		id = newid;
-		pick::site = newsite;
-		time = newtime;
-		pick::source = newsource;
-		phase = newphase;
-		polarity = newpolarity;
-		onset = newonset;
-		picker = newpicker;
+	// optional values
+	// phase
+	if (phase != "") {
+		rapidjson::Value phasevalue;
+		phasevalue.SetString(rapidjson::StringRef(phase.c_str()), allocator);
+		json.AddMember(PHASE_KEY, phasevalue, allocator);
+	}
 
-		filterdata.clear();
-		for (int i = 0; i < (int)newfilterdata.size(); i++)
-		{
-			filterdata.push_back(newfilterdata[i]);
+	// polarity
+	if (polarity != "") {
+		rapidjson::Value polarityvalue;
+		polarityvalue.SetString(rapidjson::StringRef(polarity.c_str()),
+				allocator);
+		json.AddMember(POLARITY_KEY, polarityvalue, allocator);
+	}
+
+	// onset
+	if (onset != "") {
+		rapidjson::Value onsetvalue;
+		onsetvalue.SetString(rapidjson::StringRef(onset.c_str()), allocator);
+		json.AddMember(ONSET_KEY, onsetvalue, allocator);
+	}
+
+	// picker
+	if (picker != "") {
+		rapidjson::Value pickervalue;
+		pickervalue.SetString(rapidjson::StringRef(picker.c_str()), allocator);
+		json.AddMember(PICKER_KEY, pickervalue, allocator);
+	}
+
+	// filter
+	if (filterdata.size() > 0) {
+		// build json array
+		rapidjson::Value dataarray(rapidjson::kArrayType);
+
+		for (int i = 0; i < (int) filterdata.size(); i++) {
+			rapidjson::Value filtervalue(rapidjson::kObjectType);
+			filterdata[i].tojson(filtervalue, allocator);
+			dataarray.PushBack(filtervalue, allocator);
 		}
 
-		pick::amplitude = newamplitude;
-		pick::associationinfo = detectionformats::associated();
+		if (dataarray.Size() > 0) {
+			json.AddMember(FILTER_KEY, dataarray, allocator);
+		}
 	}
 
-	pick::pick(std::string newid, detectionformats::site newsite, double newtime, detectionformats::source newsource, std::string newphase, std::string newpolarity, std::string newonset, std::string newpicker, std::vector<detectionformats::filter> newfilterdata, detectionformats::amplitude newamplitude, detectionformats::associated newassociated)
-	{
-		type = PICK_TYPE;
-		id = newid;
-		site = newsite;
-		time = newtime;
-		source = newsource;
-		phase = newphase;
-		polarity = newpolarity;
-		onset = newonset;
-		picker = newpicker;
-
-		filterdata.clear();
-		for (int i = 0; i < (int)newfilterdata.size(); i++)
-		{
-			filterdata.push_back(newfilterdata[i]);
-		}
-
-		amplitude = newamplitude;
-		associationinfo = newassociated;
+	// amplitude
+	if (pick::amplitude.isempty() == false) {
+		rapidjson::Value amplitudevalue(rapidjson::kObjectType);
+		amplitude.tojson(amplitudevalue, allocator);
+		json.AddMember(AMPLITUDE_KEY, amplitudevalue, allocator);
 	}
 
-	pick::pick(rapidjson::Value &json)
-	{
-		// required values
-		// type
-		if ((json.HasMember(TYPE_KEY) == true) && (json[TYPE_KEY].IsString() == true))
-			type = std::string(json[TYPE_KEY].GetString(), json[TYPE_KEY].GetStringLength());
-		else
-			type = "";
+	// beam
+	if (pick::beam.isempty() == false) {
+		rapidjson::Value beamvalue(rapidjson::kObjectType);
+		amplitude.tojson(beamvalue, allocator);
+		json.AddMember(BEAM_KEY, beamvalue, allocator);
+	}
 
-		// id
-		if ((json.HasMember(ID_KEY) == true) && (json[ID_KEY].IsString() == true))
-			id = std::string(json[ID_KEY].GetString(), json[ID_KEY].GetStringLength());
-		else
-			id = "";
+	// associated
+	if (associationinfo.isempty() == false) {
+		rapidjson::Value associatedvalue(rapidjson::kObjectType);
+		associationinfo.tojson(associatedvalue, allocator);
+		json.AddMember(ASSOCIATIONINFO_KEY, associatedvalue, allocator);
+	}
 
-		// site
-		if ((json.HasMember(SITE_KEY) == true) && (json[SITE_KEY].IsObject() == true))
-		{
-			rapidjson::Value & sitevalue = json["Site"];
-			site = detectionformats::site(sitevalue);
+	return (json);
+}
+
+std::vector<std::string> pick::geterrors() {
+	std::vector<std::string> errorlist;
+
+	// check for requried data
+	// Type
+	if (type != PICK_TYPE) {
+		// wrong type
+		errorlist.push_back("Non-pick type in pick class.");
+	}
+
+	// id
+	if (id == "") {
+		// empty id
+		errorlist.push_back("Empty ID in pick class.");
+	}
+
+	// site
+	if (site.isvalid() != true) {
+		// site not found
+		errorlist.push_back("Site object did not validate in pick class.");
+	}
+
+	// source
+	if (source.isvalid() != true) {
+		// bad source
+		errorlist.push_back("Source object did not validate in pick class.");
+	}
+
+	// time
+	if (std::isnan(time) == true) {
+		errorlist.push_back("Time is missing in pick class.");
+	} else {
+		try {
+			if (detectionformats::IsStringISO8601(
+					detectionformats::ConvertEpochTimeToISO8601(time))
+					== false) {
+				errorlist.push_back("Time did not validate in pick class.");
+			}
+		} catch (const std::exception & e) {
+			errorlist.push_back(std::string(e.what()));
 		}
-		else
-			site = detectionformats::site();
+	}
 
-		// source
-		if ((json.HasMember(SOURCE_KEY) == true) && (json[SOURCE_KEY].IsObject() == true))
-		{
-			rapidjson::Value & sourcevalue = json[SOURCE_KEY];
-			source = detectionformats::source(sourcevalue);
+	// optional data
+	// phase
+	if (phase != "") {
+		if (detectionformats::IsStringAlpha(phase) == false) {
+			errorlist.push_back("Phase did not validate in pick class.");
 		}
-		else
-			source = detectionformats::source();
+	}
 
-		// time
-		if ((json.HasMember(TIME_KEY) == true) && (json[TIME_KEY].IsString() == true))
-			time = detectionformats::ConvertISO8601ToEpochTime(std::string(json[TIME_KEY].GetString(), json[TIME_KEY].GetStringLength()));
-		else
-			time = std::numeric_limits<double>::quiet_NaN();
-
-		// optional values
-		// phase
-		if ((json.HasMember(PHASE_KEY) == true) && (json[PHASE_KEY].IsString() == true))
-			phase = std::string(json[PHASE_KEY].GetString(), json[PHASE_KEY].GetStringLength());
-		else
-			phase = "";
-
-		// polarity
-		if ((json.HasMember(POLARITY_KEY) == true) && (json[POLARITY_KEY].IsString() == true))
-			polarity = std::string(json[POLARITY_KEY].GetString(), json[POLARITY_KEY].GetStringLength());
-		else
-			polarity = "";
-
-		// onset
-		if ((json.HasMember(ONSET_KEY) == true) && (json[ONSET_KEY].IsString() == true))
-			onset = std::string(json[ONSET_KEY].GetString(), json[ONSET_KEY].GetStringLength());
-		else
-			onset = "";
-
-		// picker
-		if ((json.HasMember(PICKER_KEY) == true) && (json[PICKER_KEY].IsString() == true))
-			picker = std::string(json[PICKER_KEY].GetString(), json[PICKER_KEY].GetStringLength());
-		else
-			picker = "";
-
-		// filter
-		filterdata.clear();
-		if ((json.HasMember(FILTER_KEY) == true) && (json[FILTER_KEY].IsArray() == true))
-		{
-			rapidjson::Value dataarray;
-			dataarray = json[FILTER_KEY].GetArray();
-
-			for (rapidjson::SizeType i = 0; i < dataarray.Size(); i++)
-			{
-				// parse
-				rapidjson::Value & datavalue = dataarray[i];
-				detectionformats::filter newfilter(datavalue);
-
-				// add to vector
-				filterdata.push_back(newfilter);
+	// polarity
+	if (polarity != "") {
+		bool match = false;
+		// check all the valid types to see if this string matches
+		for (int i = detectionformats::polarityindex::up;
+				i < detectionformats::polarityindex::polaritycount; i++) {
+			if (polarity == polarityvalues[i]) {
+				match = true;
+				break;
 			}
 		}
 
-		// amplitude
-		if ((json.HasMember(AMPLITUDE_KEY) == true) && (json[AMPLITUDE_KEY].IsObject() == true))
-		{
-			rapidjson::Value & amplitudevalue = json[AMPLITUDE_KEY];
-			amplitude = detectionformats::amplitude(amplitudevalue);
+		if (match == false) {
+			errorlist.push_back("Invalid Polarity in pick class.");
 		}
-		else
-			amplitude = detectionformats::amplitude();
-
-		// associated
-		if ((json.HasMember(ASSOCIATIONINFO_KEY) == true) && (json[ASSOCIATIONINFO_KEY].IsObject() == true))
-		{
-			rapidjson::Value & associatedvalue = json[ASSOCIATIONINFO_KEY];
-			associationinfo = detectionformats::associated(associatedvalue);
-		}
-		else
-			associationinfo = detectionformats::associated();
 	}
 
-	pick::pick(const pick &newpick)
-	{
-		type = PICK_TYPE;
-		id = newpick.id;
-		site = newpick.site;
-		time = newpick.time;
-		source = newpick.source;
-		phase = newpick.phase;
-		polarity = newpick.polarity;
-		onset = newpick.onset;
-		picker = newpick.picker;
-
-		filterdata.clear();
-		for (int i = 0; i < (int)newpick.filterdata.size(); i++)
-		{
-			filterdata.push_back(newpick.filterdata[i]);
-		}
-
-		amplitude = newpick.amplitude;
-		associationinfo = newpick.associationinfo;
-	}
-
-	pick::~pick()
-	{
-	}
-
-	rapidjson::Value & pick::tojson(rapidjson::Value &json, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &allocator)
-	{
-		json.SetObject();
-
-		// required values
-		// type
-		rapidjson::Value typevalue;
-		typevalue.SetString(rapidjson::StringRef(type.c_str()), allocator);
-		json.AddMember(TYPE_KEY, typevalue, allocator);
-
-		// id
-		if (id != "")
-		{
-			rapidjson::Value idvalue;
-			idvalue.SetString(rapidjson::StringRef(id.c_str()), allocator);
-			json.AddMember(ID_KEY, idvalue, allocator);
-		}
-
-		// site
-		rapidjson::Value sitevalue(rapidjson::kObjectType);
-		site.tojson(sitevalue, allocator);
-		json.AddMember(SITE_KEY, sitevalue, allocator);
-
-		// source
-		rapidjson::Value sourcevalue(rapidjson::kObjectType);
-		source.tojson(sourcevalue, allocator);
-		json.AddMember(SOURCE_KEY, sourcevalue, allocator);
-
-		// time
-		if (std::isnan(time) != true)
-		{
-			std::string timestring = detectionformats::ConvertEpochTimeToISO8601(time);
-			rapidjson::Value timevalue;
-			timevalue.SetString(rapidjson::StringRef(timestring.c_str()), allocator);
-			json.AddMember(TIME_KEY, timevalue, allocator);
-		}
-
-		// optional values
-		// phase
-		if (phase != "")
-		{
-			rapidjson::Value phasevalue;
-			phasevalue.SetString(rapidjson::StringRef(phase.c_str()), allocator);
-			json.AddMember(PHASE_KEY, phasevalue, allocator);
-		}
-
-		// polarity
-		if (polarity != "")
-		{
-			rapidjson::Value polarityvalue;
-			polarityvalue.SetString(rapidjson::StringRef(polarity.c_str()), allocator);
-			json.AddMember(POLARITY_KEY, polarityvalue, allocator);
-		}
-
-		// onset
-		if (onset != "")
-		{
-			rapidjson::Value onsetvalue;
-			onsetvalue.SetString(rapidjson::StringRef(onset.c_str()), allocator);
-			json.AddMember(ONSET_KEY, onsetvalue, allocator);
-		}
-
-		// picker
-		if (picker != "")
-		{
-			rapidjson::Value pickervalue;
-			pickervalue.SetString(rapidjson::StringRef(picker.c_str()), allocator);
-			json.AddMember(PICKER_KEY, pickervalue, allocator);
-		}
-
-		// filter
-		if (filterdata.size() > 0)
-		{
-			// build json array
-			rapidjson::Value dataarray(rapidjson::kArrayType);
-
-			for (int i = 0; i < (int)filterdata.size(); i++)
-			{
-				rapidjson::Value filtervalue(rapidjson::kObjectType);
-				filterdata[i].tojson(filtervalue, allocator);
-				dataarray.PushBack(filtervalue, allocator);
-			}
-
-			if (dataarray.Size() > 0)
-			{
-				json.AddMember(FILTER_KEY, dataarray, allocator);
+	// onset
+	if (onset != "") {
+		bool match = false;
+		// check all the valid types to see if this string matches
+		for (int i = detectionformats::onsetindex::impulsive;
+				i < detectionformats::onsetindex::onsetcount; i++) {
+			if (onset == onsetvalues[i]) {
+				match = true;
+				break;
 			}
 		}
 
-		// amplitude
-		if (pick::amplitude.isempty() == false)
-		{
-			rapidjson::Value amplitudevalue(rapidjson::kObjectType);
-			amplitude.tojson(amplitudevalue, allocator);
-			json.AddMember(AMPLITUDE_KEY, amplitudevalue, allocator);
+		if (match == false) {
+			errorlist.push_back("Invalid Onset in pick class.");
 		}
-
-		// associated
-		if (associationinfo.isempty() == false)
-		{
-			rapidjson::Value associatedvalue(rapidjson::kObjectType);
-			associationinfo.tojson(associatedvalue, allocator);
-			json.AddMember(ASSOCIATIONINFO_KEY, associatedvalue, allocator);
-		}
-
-		return(json);
 	}
 
-	std::vector<std::string> pick::geterrors()
-	{
-		std::vector<std::string> errorlist;
-
-		// check for requried data
-		// Type
-		if (type != PICK_TYPE)
-		{
-			// wrong type
-			errorlist.push_back("Non-pick type in pick class.");
+	// picker
+	if (picker != "") {
+		bool match = false;
+		// check all the valid types to see if this string matches
+		for (int i = detectionformats::pickerindex::manual;
+				i < detectionformats::pickerindex::pickercount; i++) {
+			if (picker == pickervalues[i]) {
+				match = true;
+				break;
+			}
 		}
 
-		// id
-		if (id == "")
-		{
-			// empty id
-			errorlist.push_back("Empty ID in pick class.");
+		if (match == false) {
+			errorlist.push_back("Invalid Picker in pick class.");
 		}
+	}
 
-		// site
-		if (site.isvalid() != true)
-		{
+	// filter
+	if (filterdata.size() > 0) {
+		for (int i = 0; i < (int) filterdata.size(); i++) {
+			if (filterdata[i].isvalid() != true) {
+				// bad filter
+				errorlist.push_back("Invalid filter object in pick class.");
+				break;
+			}
+		}
+	}
+
+	// amplitude
+	if (amplitude.isempty() == false) {
+		if (amplitude.isvalid() != true) {
+			// amplitude invalid
+			errorlist.push_back(
+					"Amplitude object did not validate in pick class.");
+		}
+	}
+
+	// beam
+	if (beam.isempty() == false) {
+		if (beam.isvalid() != true) {
+			// beam invalid
+			errorlist.push_back(
+					"Beam object did not validate in pick class.");
+		}
+	}
+
+	// associated
+	if (associationinfo.isempty() == false) {
+		if (associationinfo.isvalid() != true) {
 			// site not found
-			errorlist.push_back("Site object did not validate in pick class.");
+			errorlist.push_back(
+					"AssociationInfo object did not validate in pick class.");
 		}
-
-		// source
-		if (source.isvalid() != true)
-		{
-			// bad source
-			errorlist.push_back("Source object did not validate in pick class.");
-		}
-
-		// time
-		if (std::isnan(time) == true)
-		{
-			errorlist.push_back("Time is missing in pick class.");
-		}
-		else
-		{
-			try
-			{
-				if (detectionformats::IsStringISO8601(detectionformats::ConvertEpochTimeToISO8601(time)) == false)
-				{
-					errorlist.push_back("Time did not validate in pick class.");
-				}
-			}
-			catch (const std::exception & e)
-			{
-				errorlist.push_back(std::string(e.what()));
-			}
-		}
-
-		// optional data
-		// phase
-		if (phase != "")
-		{
-			if (detectionformats::IsStringAlpha(phase) == false)
-			{
-				errorlist.push_back("Phase did not validate in pick class.");
-			}
-		}
-
-		// polarity
-		if (polarity != "")
-		{
-			bool match = false;
-			// check all the valid types to see if this string matches
-			for (int i = detectionformats::polarityindex::up; i < detectionformats::polarityindex::polaritycount; i++)
-			{
-				if (polarity == polarityvalues[i])
-				{
-					match = true;
-					break;
-				}
-			}
-
-			if (match == false)
-			{
-				errorlist.push_back("Invalid Polarity in pick class.");
-			}
-		}
-
-		// onset
-		if (onset != "")
-		{
-			bool match = false;
-			// check all the valid types to see if this string matches
-			for (int i = detectionformats::onsetindex::impulsive; i < detectionformats::onsetindex::onsetcount; i++)
-			{
-				if (onset == onsetvalues[i])
-				{
-					match = true;
-					break;
-				}
-			}
-
-			if (match == false)
-			{
-				errorlist.push_back("Invalid Onset in pick class.");
-			}
-		}
-
-		// picker
-		if (picker != "")
-		{
-			bool match = false;
-			// check all the valid types to see if this string matches
-			for (int i = detectionformats::pickerindex::manual; i < detectionformats::pickerindex::pickercount; i++)
-			{
-				if (picker == pickervalues[i])
-				{
-					match = true;
-					break;
-				}
-			}
-
-			if (match == false)
-			{
-				errorlist.push_back("Invalid Picker in pick class.");
-			}
-		}
-
-		// filter
-		if (filterdata.size() > 0)
-		{
-			for (int i = 0; i < (int)filterdata.size(); i++)
-			{
-				if (filterdata[i].isvalid() != true)
-				{
-					// bad source
-					errorlist.push_back("Invalid filter object in pick class.");
-					break;
-				}
-			}
-		}
-
-		// amplitude
-		if (amplitude.isempty() == false)
-		{
-			if (amplitude.isvalid() != true)
-			{
-				// site not found
-				errorlist.push_back("Amplitude object did not validate in pick class.");
-			}
-		}
-
-		// associated
-		if (associationinfo.isempty() == false)
-		{
-			if (associationinfo.isvalid() != true)
-			{
-				// site not found
-				errorlist.push_back("AssociationInfo object did not validate in pick class.");
-			}
-		}
-
-		// since id and phase are free text strings, no further validation is required.
-		// NOTE: Further validation COULD be done to confirm that phase is a valid phase name
-
-		// return the list of errors
-		return (errorlist);
 	}
+
+	// since id and phase are free text strings, no further validation is required.
+	// NOTE: Further validation COULD be done to confirm that phase is a valid phase name
+
+	// return the list of errors
+	return (errorlist);
+}
 
 }

--- a/cpp/src/site.cpp
+++ b/cpp/src/site.cpp
@@ -1,159 +1,135 @@
 #include "site.h"
 // JSON Keys
-#define SITEID_KEY "SiteID"
 #define STATION_KEY "Station"
 #define CHANNEL_KEY "Channel"
 #define NETWORK_KEY "Network"
 #define LOCATION_KEY "Location"
 
-namespace detectionformats
-{
-	site::site()
-	{
-		siteid = "";
+namespace detectionformats {
+site::site() {
+	station = "";
+	channel = "";
+	network = "";
+	location = "";
+}
+
+site::site(std::string newstation, std::string newchannel,
+		std::string newnetwork, std::string newlocation) {
+	station = newstation;
+	channel = newchannel;
+	network = newnetwork;
+	location = newlocation;
+}
+
+site::site(rapidjson::Value &json) {
+
+	// required values
+	// station
+	if ((json.HasMember(STATION_KEY) == true)
+			&& (json[STATION_KEY].IsString() == true))
+		station = std::string(json[STATION_KEY].GetString(),
+				json[STATION_KEY].GetStringLength());
+	else
 		station = "";
-		channel = "";
+
+	// network
+	if ((json.HasMember(NETWORK_KEY) == true)
+			&& (json[NETWORK_KEY].IsString() == true))
+		network = std::string(json[NETWORK_KEY].GetString(),
+				json[NETWORK_KEY].GetStringLength());
+	else
 		network = "";
+
+	// optional values
+	// channel
+	if ((json.HasMember(CHANNEL_KEY) == true)
+			&& (json[CHANNEL_KEY].IsString() == true))
+		channel = std::string(json[CHANNEL_KEY].GetString(),
+				json[CHANNEL_KEY].GetStringLength());
+	else
+		channel = "";
+
+	// location
+	if ((json.HasMember(LOCATION_KEY) == true)
+			&& (json[LOCATION_KEY].IsString() == true))
+		location = std::string(json[LOCATION_KEY].GetString(),
+				json[LOCATION_KEY].GetStringLength());
+	else
 		location = "";
+}
+
+site::site(const site & newsite) {
+	station = newsite.station;
+	channel = newsite.channel;
+	network = newsite.network;
+	location = newsite.location;
+}
+
+site::~site() {
+}
+
+rapidjson::Value & site::tojson(rapidjson::Value &json,
+		rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &allocator) {
+	json.SetObject();
+
+	// required values
+	// station
+	if (station != "") {
+		rapidjson::Value stationvalue;
+		stationvalue.SetString(rapidjson::StringRef(station.c_str()),
+				allocator);
+		json.AddMember(STATION_KEY, stationvalue, allocator);
+	}
+	// network
+	if (network != "") {
+		rapidjson::Value networkvalue;
+		networkvalue.SetString(rapidjson::StringRef(network.c_str()),
+				allocator);
+		json.AddMember(NETWORK_KEY, networkvalue, allocator);
 	}
 
-	site::site(std::string newsiteid, std::string newstation, std::string newchannel, std::string newnetwork, std::string newlocation)
-	{
-		siteid = newsiteid;
-		station = newstation;
-		channel = newchannel;
-		network = newnetwork;
-		location = newlocation;
+	// optional values
+	// channel
+	if (channel != "") {
+		rapidjson::Value channelvalue;
+		channelvalue.SetString(rapidjson::StringRef(channel.c_str()),
+				allocator);
+		json.AddMember(CHANNEL_KEY, channelvalue, allocator);
 	}
 
-	site::site(rapidjson::Value &json)
-	{
-
-		// required values
-		// siteid
-		if ((json.HasMember(SITEID_KEY) == true) && (json[SITEID_KEY].IsString() == true))
-			siteid = std::string(json[SITEID_KEY].GetString(), json[SITEID_KEY].GetStringLength());
-		else
-			siteid = "";
-
-		// station
-		if ((json.HasMember(STATION_KEY) == true) && (json[STATION_KEY].IsString() == true))
-			station = std::string(json[STATION_KEY].GetString(), json[STATION_KEY].GetStringLength());
-		else
-			station = "";
-
-		// network
-		if ((json.HasMember(NETWORK_KEY) == true) && (json[NETWORK_KEY].IsString() == true))
-			network = std::string(json[NETWORK_KEY].GetString(), json[NETWORK_KEY].GetStringLength());
-		else
-			network = "";
-
-		// optional values
-		// channel
-		if ((json.HasMember(CHANNEL_KEY) == true) && (json[CHANNEL_KEY].IsString() == true))
-			channel = std::string(json[CHANNEL_KEY].GetString(), json[CHANNEL_KEY].GetStringLength());
-		else
-			channel = "";
-
-		// location
-		if ((json.HasMember(LOCATION_KEY) == true) && (json[LOCATION_KEY].IsString() == true))
-			location = std::string(json[LOCATION_KEY].GetString(), json[LOCATION_KEY].GetStringLength());
-		else
-			location = "";
+	// location
+	if (location != "") {
+		rapidjson::Value locationvalue;
+		locationvalue.SetString(rapidjson::StringRef(location.c_str()),
+				allocator);
+		json.AddMember(LOCATION_KEY, locationvalue, allocator);
 	}
 
-	site::site(const site & newsite)
-	{
-		siteid = newsite.siteid;
-		station = newsite.station;
-		channel = newsite.channel;
-		network = newsite.network;
-		location = newsite.location;
+	return (json);
+}
+
+std::vector<std::string> site::geterrors() {
+	std::vector<std::string> errorlist;
+
+	// check for required keys
+	// Station
+	if (station == "") {
+		// empty Station
+		errorlist.push_back("Empty Station in site class.");
 	}
 
-	site::~site()
-	{
+	// Network
+	if (network == "") {
+		// empty network
+		errorlist.push_back("Empty Network in site class.");
 	}
 
-	rapidjson::Value & site::tojson(rapidjson::Value &json, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &allocator)
-	{
-		json.SetObject();
+	// since station, channel, network, and location are free text strings, no
+	// further  validation is required.  channel and location are also optional
+	// NOTE: Further validation COULD be done to confirm that values matched
+	// seed standards.
 
-		// required values
-		// siteid
-		if (siteid != "")
-		{
-			rapidjson::Value siteidvalue;
-			siteidvalue.SetString(rapidjson::StringRef(siteid.c_str()), allocator);
-			json.AddMember(SITEID_KEY, siteidvalue, allocator);
-		}
-
-		// station
-		if (station != "")
-		{
-			rapidjson::Value stationvalue;
-			stationvalue.SetString(rapidjson::StringRef(station.c_str()), allocator);
-			json.AddMember(STATION_KEY, stationvalue, allocator);
-		}
-		// network
-		if (network != "")
-		{
-			rapidjson::Value networkvalue;
-			networkvalue.SetString(rapidjson::StringRef(network.c_str()), allocator);
-			json.AddMember(NETWORK_KEY, networkvalue, allocator);
-		}
-
-		// optional values
-		// channel
-		if (channel != "")
-		{
-			rapidjson::Value channelvalue;
-			channelvalue.SetString(rapidjson::StringRef(channel.c_str()), allocator);
-			json.AddMember(CHANNEL_KEY, channelvalue, allocator);
-		}
-
-		// location
-		if (location != "")
-		{
-			rapidjson::Value locationvalue;
-			locationvalue.SetString(rapidjson::StringRef(location.c_str()), allocator);
-			json.AddMember(LOCATION_KEY, locationvalue, allocator);
-		}
-
-		return (json);
-	}
-
-	std::vector<std::string> site::geterrors()
-	{
-		std::vector<std::string> errorlist;
-
-		// check for requried keys
-		// SiteID
-		if (siteid == "")
-		{
-			// empty SiteID
-			errorlist.push_back("Empty SiteID in site class.");
-		}
-
-		// Station
-		if (station == "")
-		{
-			// empty Station
-			errorlist.push_back("Empty Station in site class.");
-		}
-
-		// Network
-		if (network == "")
-		{
-			// empty network
-			errorlist.push_back("Empty Network in site class.");
-		}
-
-		// since siteid, station, channel, network, and location are free text strings, no further 
-		// validation is required.  channel and location are also optional
-		// NOTE: Further validation COULD be done to confirm that values matched seed standards.
-
-		// return the list of errors
-		return (errorlist);
-	}
+	// return the list of errors
+	return (errorlist);
+}
 }

--- a/cpp/tests/beam_unittest.cpp
+++ b/cpp/tests/beam_unittest.cpp
@@ -4,81 +4,15 @@
 #include <string>
 
 // test data
-#define BEAMSTRING "{\"Type\":\"Beam\",\"ID\":\"12GFH48776857\",\"Site\":{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"StartTime\":\"2015-12-28T21:32:24.017Z\",\"EndTime\":\"2015-12-28T21:32:30.017Z\",\"BackAzimuth\":2.65,\"Slowness\":1.44,\"PowerRatio\":12.18,\"BackAzimuthError\":3.8,\"SlownessError\":0.4,\"PowerRatioError\":0.557,\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}"
-#define ID "12GFH48776857"
-#define STATION "BMN"
-#define CHANNEL "HHZ"
-#define NETWORK "LB"
-#define LOCATION "01"
-#define SITEID "BMN.HHZ.LB.01"
-#define AGENCYID "US"
-#define AUTHOR "TestAuthor"
-#define STARTTIME "2015-12-28T21:32:24.017Z"
-#define ENDTIME "2015-12-28T21:32:30.017Z"
+#define BEAMSTRING "{\"BackAzimuth\":2.65,\"Slowness\":1.44,\"PowerRatio\":12.18,\"BackAzimuthError\":3.8,\"SlownessError\":0.4,\"PowerRatioError\":0.557}"
 #define BACKAZIMUTH 2.65
 #define BACKAZIMUTHERROR 3.8
 #define SLOWNESS 1.44
 #define SLOWNESSERROR 0.4
 #define POWERRATIO 12.18
 #define POWERRATIOERROR 0.557
-#define ASSOCPHASE "P"
-#define ASSOCDISTANCE 0.442559
-#define ASSOCAZIMUTH 0.418479
-#define ASSOCRESIDUAL -0.025393
-#define ASSOCSIGMA 0.086333
 
 void checkdata(detectionformats::beam beamobject, std::string testinfo) {
-	// check id
-	std::string beamid = beamobject.id;
-	std::string expectedid = std::string(ID);
-	ASSERT_STREQ(beamid.c_str(), expectedid.c_str());
-
-	// check station
-	std::string sitestation = beamobject.site.station;
-	std::string expectedstation = std::string(STATION);
-	ASSERT_STREQ(sitestation.c_str(), expectedstation.c_str());
-
-	// check channel
-	std::string sitechannel = beamobject.site.channel;
-	std::string expectedchannel = std::string(CHANNEL);
-	ASSERT_STREQ(sitechannel.c_str(), expectedchannel.c_str());
-
-	// check network
-	std::string sitenetwork = beamobject.site.network;
-	std::string expectednetwork = std::string(NETWORK);
-	ASSERT_STREQ(sitenetwork.c_str(), expectednetwork.c_str());
-
-	// check location
-	std::string sitelocation = beamobject.site.location;
-	std::string expectedlocation = std::string(LOCATION);
-	ASSERT_STREQ(sitelocation.c_str(), expectedlocation.c_str());
-
-	// check siteid
-	std::string sitesiteid = beamobject.site.siteid;
-	std::string expectedsiteid = std::string(SITEID);
-	ASSERT_STREQ(sitesiteid.c_str(), expectedsiteid.c_str());
-
-	// check agencyid
-	std::string sourceagencyid = beamobject.source.agencyid;
-	std::string expectedagencyid = std::string(AGENCYID);
-	ASSERT_STREQ(sourceagencyid.c_str(), expectedagencyid.c_str());
-
-	// check author
-	std::string sourceauthor = beamobject.source.author;
-	std::string expectedauthor = std::string(AUTHOR);
-	ASSERT_STREQ(sourceauthor.c_str(), expectedauthor.c_str());
-
-	// check start time
-	double beamstarttime = beamobject.starttime;
-	double expectedstarttime = detectionformats::ConvertISO8601ToEpochTime(
-			std::string(STARTTIME));
-	ASSERT_EQ(beamstarttime, expectedstarttime);
-
-	// check end time
-	double beamendtime = beamobject.endtime;
-	double expectedendtime = detectionformats::ConvertISO8601ToEpochTime(
-			std::string(ENDTIME));
-	ASSERT_EQ(beamendtime, expectedendtime);
 
 	// check backazimuth
 	double beambackazimuth = beamobject.backazimuth;
@@ -86,54 +20,35 @@ void checkdata(detectionformats::beam beamobject, std::string testinfo) {
 	ASSERT_EQ(beambackazimuth, expectedbackazimuth);
 
 	// check backazimutherror
-	double beambackazimutherror = beamobject.backazimutherror;
-	double expectedbackazimutherror = BACKAZIMUTHERROR;
-	ASSERT_EQ(beambackazimutherror, expectedbackazimutherror);
-
+	if (std::isnan(beamobject.backazimutherror) != true) {
+		double beambackazimutherror = beamobject.backazimutherror;
+		double expectedbackazimutherror = BACKAZIMUTHERROR;
+		ASSERT_EQ(beambackazimutherror, expectedbackazimutherror);
+	}
 	// check slowness
 	double beamslowness = beamobject.slowness;
 	double expectedslowness = SLOWNESS;
 	ASSERT_EQ(beamslowness, expectedslowness);
 
 	// check slownesserror
-	double beamslownesserrorr = beamobject.slownesserror;
-	double expectedslownesserror = SLOWNESSERROR;
-	ASSERT_EQ(beamslownesserrorr, expectedslownesserror);
-
+	if (std::isnan(beamobject.slownesserror) != true) {
+		double beamslownesserrorr = beamobject.slownesserror;
+		double expectedslownesserror = SLOWNESSERROR;
+		ASSERT_EQ(beamslownesserrorr, expectedslownesserror);
+	}
 	// check powerratio
-	double beampowerratio = beamobject.powerratio;
-	double expectedpowerratio = POWERRATIO;
-	ASSERT_EQ(beampowerratio, expectedpowerratio);
+	if (std::isnan(beamobject.powerratio) != true) {
+		double beampowerratio = beamobject.powerratio;
+		double expectedpowerratio = POWERRATIO;
+		ASSERT_EQ(beampowerratio, expectedpowerratio);
+	}
 
 	// check powerratioerror
-	double beampowerratioerrorr = beamobject.powerratioerror;
-	double expectedpowerratioerror = POWERRATIOERROR;
-	ASSERT_EQ(beampowerratioerrorr, expectedpowerratioerror);
-
-	// check phase
-	std::string associatedphase = beamobject.associationinfo.phase;
-	std::string expectedphase = std::string(ASSOCPHASE);
-	ASSERT_STREQ(associatedphase.c_str(), expectedphase.c_str());
-
-	// check distance
-	double associateddistance = beamobject.associationinfo.distance;
-	double expecteddistance = ASSOCDISTANCE;
-	ASSERT_EQ(associateddistance, expecteddistance);
-
-	// check azimuth
-	double associatedazimuth = beamobject.associationinfo.azimuth;
-	double expectedazimuth = ASSOCAZIMUTH;
-	ASSERT_EQ(associatedazimuth, expectedazimuth);
-
-	// check residual
-	double associatedresidual = beamobject.associationinfo.residual;
-	double expectedresidual = ASSOCRESIDUAL;
-	ASSERT_EQ(associatedresidual, expectedresidual);
-
-	// check sigma
-	double associatedsigma = beamobject.associationinfo.sigma;
-	double expectedsigma = ASSOCSIGMA;
-	ASSERT_EQ(associatedsigma, expectedsigma);
+	if (std::isnan(beamobject.powerratioerror) != true) {
+		double beampowerratioerrorr = beamobject.powerratioerror;
+		double expectedpowerratioerror = POWERRATIOERROR;
+		ASSERT_EQ(beampowerratioerrorr, expectedpowerratioerror);
+	}
 }
 
 // tests to see if beam can successfully
@@ -141,37 +56,12 @@ void checkdata(detectionformats::beam beamobject, std::string testinfo) {
 TEST(BeamTest, WritesJSON) {
 	detectionformats::beam beamobject;
 
-	// build beam object
-	beamobject.id = std::string(ID);
-
-	// site subobject
-	beamobject.site.siteid = std::string(SITEID);
-	beamobject.site.station = std::string(STATION);
-	beamobject.site.channel = std::string(CHANNEL);
-	beamobject.site.network = std::string(NETWORK);
-	beamobject.site.location = std::string(LOCATION);
-
-	// source subobject
-	beamobject.source.agencyid = std::string(AGENCYID);
-	beamobject.source.author = std::string(AUTHOR);
-
-	beamobject.starttime = detectionformats::ConvertISO8601ToEpochTime(
-			std::string(STARTTIME));
-	beamobject.endtime = detectionformats::ConvertISO8601ToEpochTime(
-			std::string(ENDTIME));
 	beamobject.backazimuth = BACKAZIMUTH;
 	beamobject.backazimutherror = BACKAZIMUTHERROR;
 	beamobject.slowness = SLOWNESS;
 	beamobject.slownesserror = SLOWNESSERROR;
 	beamobject.powerratio = POWERRATIO;
 	beamobject.powerratioerror = POWERRATIOERROR;
-
-	// association subobject
-	beamobject.associationinfo.phase = std::string(ASSOCPHASE);
-	beamobject.associationinfo.distance = ASSOCDISTANCE;
-	beamobject.associationinfo.azimuth = ASSOCAZIMUTH;
-	beamobject.associationinfo.residual = ASSOCRESIDUAL;
-	beamobject.associationinfo.sigma = ASSOCSIGMA;
 
 	// build json string
 	rapidjson::Document beamdocument;
@@ -204,48 +94,19 @@ TEST(BeamTest, ReadsJSON) {
 // be constructed
 TEST(BeamTest, Constructor) {
 	// use constructor
-	detectionformats::beam beamobject(std::string(ID), std::string(SITEID),
-			std::string(STATION), std::string(CHANNEL), std::string(NETWORK),
-			std::string(LOCATION), std::string(AGENCYID), std::string(AUTHOR),
-			detectionformats::ConvertISO8601ToEpochTime(std::string(STARTTIME)),
-			detectionformats::ConvertISO8601ToEpochTime(std::string(ENDTIME)),
-			BACKAZIMUTH, BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
-			POWERRATIOERROR,
-			std::string(ASSOCPHASE), ASSOCDISTANCE,
-			ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
+	detectionformats::beam beamobject(BACKAZIMUTH, BACKAZIMUTHERROR, SLOWNESS,
+	SLOWNESSERROR, POWERRATIO, POWERRATIOERROR);
 
 	// check data values
 	checkdata(beamobject, "Tested constructor.");
-
-	// use alternate constructor
-	detectionformats::beam beamobject_altc(std::string(ID),
-			detectionformats::site(std::string(SITEID), std::string(STATION),
-					std::string(CHANNEL), std::string(NETWORK),
-					std::string(LOCATION)),
-			detectionformats::source(std::string(AGENCYID),
-					std::string(AUTHOR)),
-			detectionformats::ConvertISO8601ToEpochTime(std::string(STARTTIME)),
-			detectionformats::ConvertISO8601ToEpochTime(std::string(ENDTIME)),
-			BACKAZIMUTH, BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
-			POWERRATIOERROR, detectionformats::associated(std::string(ASSOCPHASE),
-			ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA));
-
-	// check data values
-	checkdata(beamobject_altc, "Tested alternate constructor.");
 }
 
 // tests to see if beam can successfully
 // be copy constructed
 TEST(BeamTest, CopyConstructor) {
 	// use constructor
-	detectionformats::beam frombeamobject(std::string(ID), std::string(SITEID),
-			std::string(STATION), std::string(CHANNEL), std::string(NETWORK),
-			std::string(LOCATION), std::string(AGENCYID), std::string(AUTHOR),
-			detectionformats::ConvertISO8601ToEpochTime(std::string(STARTTIME)),
-			detectionformats::ConvertISO8601ToEpochTime(std::string(ENDTIME)),
-			BACKAZIMUTH, BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
-			POWERRATIOERROR, std::string(ASSOCPHASE), ASSOCDISTANCE,
-			ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
+	detectionformats::beam frombeamobject(BACKAZIMUTH, BACKAZIMUTHERROR,
+	SLOWNESS, SLOWNESSERROR, POWERRATIO, POWERRATIOERROR);
 
 	detectionformats::beam beamobject(frombeamobject);
 
@@ -258,37 +119,12 @@ TEST(BeamTest, CopyConstructor) {
 TEST(BeamTest, Validate) {
 	detectionformats::beam beamobject;
 
-	// build beam object
-	beamobject.id = std::string(ID);
-
-	// site subobject
-	beamobject.site.siteid = std::string(SITEID);
-	beamobject.site.station = std::string(STATION);
-	beamobject.site.channel = std::string(CHANNEL);
-	beamobject.site.network = std::string(NETWORK);
-	beamobject.site.location = std::string(LOCATION);
-
-	// source subobject
-	beamobject.source.agencyid = std::string(AGENCYID);
-	beamobject.source.author = std::string(AUTHOR);
-
-	beamobject.starttime = detectionformats::ConvertISO8601ToEpochTime(
-			std::string(STARTTIME));
-	beamobject.endtime = detectionformats::ConvertISO8601ToEpochTime(
-			std::string(ENDTIME));
 	beamobject.backazimuth = BACKAZIMUTH;
 	beamobject.backazimutherror = BACKAZIMUTHERROR;
 	beamobject.slowness = SLOWNESS;
 	beamobject.slownesserror = SLOWNESSERROR;
 	beamobject.powerratio = POWERRATIO;
 	beamobject.powerratioerror = POWERRATIOERROR;
-
-	// association subobject
-	beamobject.associationinfo.phase = std::string(ASSOCPHASE);
-	beamobject.associationinfo.distance = ASSOCDISTANCE;
-	beamobject.associationinfo.azimuth = ASSOCAZIMUTH;
-	beamobject.associationinfo.residual = ASSOCRESIDUAL;
-	beamobject.associationinfo.sigma = ASSOCSIGMA;
 
 	// successful validation
 	bool result = beamobject.isvalid();
@@ -298,7 +134,7 @@ TEST(BeamTest, Validate) {
 
 	// build bad beam object
 	detectionformats::beam badbeamobject;
-	beamobject.id = "";
+	beamobject.backazimuth = std::numeric_limits<double>::quiet_NaN();
 
 	result = false;
 	try {

--- a/cpp/tests/correlation_unittest.cpp
+++ b/cpp/tests/correlation_unittest.cpp
@@ -4,13 +4,12 @@
 #include <string>
 
 // test data
-#define CORRELATIONSTRING "{\"ZScore\":33.67,\"Site\":{\"Station\":\"BMN\",\"Channel\":\"HHZ\",\"Network\":\"LB\",\"Location\":\"01\",\"SiteID\":\"BMN.HHZ.LB.01\"},\"Magnitude\":2.14,\"Type\":\"Correlation\",\"Correlation\":2.65,\"EventType\":\"earthquake\",\"AssociationInfo\":{\"Distance\":0.442559,\"Azimuth\":0.418479,\"Phase\":\"P\",\"Sigma\":0.086333,\"Residual\":-0.025393},\"DetectionThreshold\":1.5,\"Source\":{\"Author\":\"TestAuthor\",\"AgencyID\":\"US\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Hypocenter\":{\"TimeError\":1.984,\"Time\":\"2015-12-28T21:30:44.039Z\",\"LongitudeError\":22.64,\"LatitudeError\":12.5,\"DepthError\":2.44,\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44},\"SNR\":3.8,\"ID\":\"12GFH48776857\",\"ThresholdType\":\"minimum\",\"Phase\":\"P\"}"
+#define CORRELATIONSTRING "{\"ZScore\":33.67,\"Site\":{\"Station\":\"BMN\",\"Channel\":\"HHZ\",\"Network\":\"LB\",\"Location\":\"01\"},\"Magnitude\":2.14,\"Type\":\"Correlation\",\"Correlation\":2.65,\"EventType\":\"earthquake\",\"AssociationInfo\":{\"Distance\":0.442559,\"Azimuth\":0.418479,\"Phase\":\"P\",\"Sigma\":0.086333,\"Residual\":-0.025393},\"DetectionThreshold\":1.5,\"Source\":{\"Author\":\"TestAuthor\",\"AgencyID\":\"US\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Hypocenter\":{\"TimeError\":1.984,\"Time\":\"2015-12-28T21:30:44.039Z\",\"LongitudeError\":22.64,\"LatitudeError\":12.5,\"DepthError\":2.44,\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44},\"SNR\":3.8,\"ID\":\"12GFH48776857\",\"ThresholdType\":\"minimum\",\"Phase\":\"P\"}"
 #define ID "12GFH48776857"
 #define STATION "BMN"
 #define CHANNEL "HHZ"
 #define NETWORK "LB"
 #define LOCATION "01"
-#define SITEID "BMN.HHZ.LB.01"
 #define AGENCYID "US"
 #define AUTHOR "TestAuthor"
 #define TIME "2015-12-28T21:32:24.017Z"
@@ -62,11 +61,6 @@ void checkdata(detectionformats::correlation correlationobject,
 	std::string sitelocation = correlationobject.site.location;
 	std::string expectedlocation = std::string(LOCATION);
 	ASSERT_STREQ(sitelocation.c_str(), expectedlocation.c_str());
-
-	// check siteid
-	std::string sitesiteid = correlationobject.site.siteid;
-	std::string expectedsiteid = std::string(SITEID);
-	ASSERT_STREQ(sitesiteid.c_str(), expectedsiteid.c_str());
 
 	// check agencyid
 	std::string sourceagencyid = correlationobject.source.agencyid;
@@ -202,7 +196,6 @@ TEST(CorrelationTest, WritesJSON) {
 	correlationobject.id = std::string(ID);
 
 	// site subobject
-	correlationobject.site.siteid = std::string(SITEID);
 	correlationobject.site.station = std::string(STATION);
 	correlationobject.site.channel = std::string(CHANNEL);
 	correlationobject.site.network = std::string(NETWORK);
@@ -274,7 +267,7 @@ TEST(CorrelationTest, ReadsJSON) {
 TEST(CorrelationTest, Constructor) {
 	// use constructor
 	detectionformats::correlation correlationobject(std::string(ID),
-			std::string(SITEID), std::string(STATION), std::string(CHANNEL),
+			std::string(STATION), std::string(CHANNEL),
 			std::string(NETWORK), std::string(LOCATION), std::string(AGENCYID),
 			std::string(AUTHOR), std::string(PHASE),
 			detectionformats::ConvertISO8601ToEpochTime(std::string(TIME)),
@@ -290,7 +283,7 @@ TEST(CorrelationTest, Constructor) {
 	checkdata(correlationobject, "Tested Constructor");
 
 	detectionformats::correlation correlationobject_altc(std::string(ID),
-			detectionformats::site(std::string(SITEID), std::string(STATION),
+			detectionformats::site(std::string(STATION),
 					std::string(CHANNEL), std::string(NETWORK),
 					std::string(LOCATION)),
 			detectionformats::source(std::string(AGENCYID),
@@ -316,7 +309,7 @@ TEST(CorrelationTest, Constructor) {
 TEST(CorrelationTest, CopyConstructor) {
 	// use constructor
 	detectionformats::correlation fromcorrelationobject(std::string(ID),
-			std::string(SITEID), std::string(STATION), std::string(CHANNEL),
+			std::string(STATION), std::string(CHANNEL),
 			std::string(NETWORK), std::string(LOCATION), std::string(AGENCYID),
 			std::string(AUTHOR), std::string(PHASE),
 			detectionformats::ConvertISO8601ToEpochTime(std::string(TIME)),
@@ -343,7 +336,6 @@ TEST(CorrelationTest, Validate) {
 	correlationobject.id = std::string(ID);
 
 	// site subobject
-	correlationobject.site.siteid = std::string(SITEID);
 	correlationobject.site.station = std::string(STATION);
 	correlationobject.site.channel = std::string(CHANNEL);
 	correlationobject.site.network = std::string(NETWORK);

--- a/cpp/tests/detection_unittest.cpp
+++ b/cpp/tests/detection_unittest.cpp
@@ -4,7 +4,7 @@
 #include <string>
 
 // test data
-#define DETECTIONSTRING "{\"Type\":\"Detection\",\"ID\":\"12GFH48776857\",\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Hypocenter\":{\"TimeError\":1.984,\"Time\":\"2015-12-28T21:32:24.017Z\",\"LongitudeError\":22.64,\"LatitudeError\":12.5,\"DepthError\":2.44,\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44},\"DetectionType\":\"New\",\"EventType\":\"earthquake\",\"Bayes\":2.65,\"MinimumDistance\":2.14,\"RMS\":3.8,\"Gap\":33.67,\"Data\":[{\"Type\":\"Pick\",\"ID\":\"12GFH48776857\",\"Site\":{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Onset\":\"questionable\",\"Picker\":\"manual\",\"Filter\":[{\"HighPass\":1.05,\"LowPass\":2.65}],\"Amplitude\":{\"Amplitude\":21.5,\"Period\":2.65,\"SNR\":3.8},\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}},{\"Type\":\"Beam\",\"ID\":\"12GFH48776857\",\"Site\":{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"BackAzimuth\":2.65,\"Slowness\":1.44,\"PowerRatio\":12.18,\"BackAzimuthError\":3.8,\"SlownessError\":0.4,\"PowerRatioError\":0.557,\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}},{\"Type\":\"Correlation\",\"ID\":\"12GFH48776857\",\"Site\":{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Phase\":\"P\",\"Time\":\"2015-12-28T21:32:24.017Z\",\"Correlation\":2.65,\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44,\"OriginTime\":\"2015-12-28T21:30:44.039Z\",\"EventType\":\"earthquake\",\"Magnitude\":2.14,\"SNR\":3.8,\"ZScore\":33.67,\"DetectionThreshold\":1.5,\"ThresholdType\":\"minimum\",\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}]}"
+#define DETECTIONSTRING "{\"Type\":\"Detection\",\"ID\":\"12GFH48776857\",\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Hypocenter\":{\"TimeError\":1.984,\"Time\":\"2015-12-28T21:32:24.017Z\",\"LongitudeError\":22.64,\"LatitudeError\":12.5,\"DepthError\":2.44,\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44},\"DetectionType\":\"New\",\"EventType\":\"earthquake\",\"Bayes\":2.65,\"MinimumDistance\":2.14,\"RMS\":3.8,\"Gap\":33.67,\"Data\":[{\"Type\":\"Pick\",\"ID\":\"12GFH48776857\",\"Site\":{\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Onset\":\"questionable\",\"Picker\":\"manual\",\"Filter\":[{\"HighPass\":1.05,\"LowPass\":2.65}],\"Amplitude\":{\"Amplitude\":21.5,\"Period\":2.65,\"SNR\":3.8},\"Beam\":{\"BackAzimuth\":2.65,\"Slowness\":1.44,\"PowerRatio\":12.18,\"BackAzimuthError\":3.8,\"SlownessError\":0.4,\"PowerRatioError\":0.557},\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}},{\"Type\":\"Correlation\",\"ID\":\"12GFH48776857\",\"Site\":{\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Phase\":\"P\",\"Time\":\"2015-12-28T21:32:24.017Z\",\"Correlation\":2.65,\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44,\"OriginTime\":\"2015-12-28T21:30:44.039Z\",\"EventType\":\"earthquake\",\"Magnitude\":2.14,\"SNR\":3.8,\"ZScore\":33.67,\"DetectionThreshold\":1.5,\"ThresholdType\":\"minimum\",\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}]}"
 #define ID "12GFH48776857"
 #define AGENCYID "US"
 #define AUTHOR "TestAuthor"
@@ -22,9 +22,8 @@
 #define MINIMUMDISTANCE 2.14
 #define RMS 3.8
 #define GAP 33.67
-#define PICKDATA "{\"Type\":\"Pick\",\"ID\":\"12GFH48776857\",\"Site\":{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Onset\":\"questionable\",\"Picker\":\"manual\",\"Filter\":[{\"HighPass\":1.05,\"LowPass\":2.65}],\"Amplitude\":{\"Amplitude\":21.5,\"Period\":2.65,\"SNR\":3.8},\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}"
-#define BEAMDATA "{\"Type\":\"Beam\",\"ID\":\"12GFH48776857\",\"Site\":{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"StartTime\":\"2015-12-28T21:32:24.017Z\",\"EndTime\":\"2015-12-28T21:32:30.017Z\",\"BackAzimuth\":2.65,\"Slowness\":1.44,\"PowerRatio\":12.18,\"BackAzimuthError\":3.8,\"SlownessError\":0.4,\"PowerRatioError\":0.557,\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}"
-#define CORRELATIONDATA "{\"ZScore\":33.67,\"Site\":{\"Station\":\"BMN\",\"Channel\":\"HHZ\",\"Network\":\"LB\",\"Location\":\"01\",\"SiteID\":\"BMN.HHZ.LB.01\"},\"Magnitude\":2.14,\"Type\":\"Correlation\",\"Correlation\":2.65,\"EventType\":\"earthquake\",\"AssociationInfo\":{\"Distance\":0.442559,\"Azimuth\":0.418479,\"Phase\":\"P\",\"Sigma\":0.086333,\"Residual\":-0.025393},\"DetectionThreshold\":1.5,\"Source\":{\"Author\":\"TestAuthor\",\"AgencyID\":\"US\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Hypocenter\":{\"TimeError\":1.984,\"Time\":\"2015-12-28T21:30:44.039Z\",\"LongitudeError\":22.64,\"LatitudeError\":12.5,\"DepthError\":2.44,\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44},\"SNR\":3.8,\"ID\":\"12GFH48776857\",\"ThresholdType\":\"minimum\",\"Phase\":\"P\"}"
+#define PICKDATA "{\"Type\":\"Pick\",\"ID\":\"12GFH48776857\",\"Site\":{\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Onset\":\"questionable\",\"Picker\":\"manual\",\"Filter\":[{\"HighPass\":1.05,\"LowPass\":2.65},{\"HighPass\":2.10,\"LowPass\":3.58}],\"Amplitude\":{\"Amplitude\":21.5,\"Period\":2.65,\"SNR\":3.8},\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333},\"Beam\":{\"BackAzimuth\":2.65,\"Slowness\":1.44,\"PowerRatio\":12.18,\"BackAzimuthError\":3.8,\"SlownessError\":0.4,\"PowerRatioError\":0.557}}"
+#define CORRELATIONDATA "{\"ZScore\":33.67,\"Site\":{\"Station\":\"BMN\",\"Channel\":\"HHZ\",\"Network\":\"LB\",\"Location\":\"01\"},\"Magnitude\":2.14,\"Type\":\"Correlation\",\"Correlation\":2.65,\"EventType\":\"earthquake\",\"AssociationInfo\":{\"Distance\":0.442559,\"Azimuth\":0.418479,\"Phase\":\"P\",\"Sigma\":0.086333,\"Residual\":-0.025393},\"DetectionThreshold\":1.5,\"Source\":{\"Author\":\"TestAuthor\",\"AgencyID\":\"US\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Hypocenter\":{\"TimeError\":1.984,\"Time\":\"2015-12-28T21:30:44.039Z\",\"LongitudeError\":22.64,\"LatitudeError\":12.5,\"DepthError\":2.44,\"Latitude\":40.3344,\"Longitude\":-121.44,\"Depth\":32.44},\"SNR\":3.8,\"ID\":\"12GFH48776857\",\"ThresholdType\":\"minimum\",\"Phase\":\"P\"}"
 
 std::vector<detectionformats::pick> buildpickdata() {
 	std::vector<detectionformats::pick> newpickdata;
@@ -37,19 +36,6 @@ std::vector<detectionformats::pick> buildpickdata() {
 	newpickdata.push_back(pickobject);
 
 	return (newpickdata);
-}
-
-std::vector<detectionformats::beam> buildbeamdata() {
-	std::vector<detectionformats::beam> newbeamdata;
-
-	// beam ?need one more?
-	rapidjson::Document beamdocument;
-	detectionformats::beam beamobject(
-			detectionformats::FromJSONString(std::string(BEAMDATA),
-					beamdocument));
-	newbeamdata.push_back(beamobject);
-
-	return (newbeamdata);
 }
 
 std::vector<detectionformats::correlation> buildcorrleationdata() {
@@ -65,7 +51,8 @@ std::vector<detectionformats::correlation> buildcorrleationdata() {
 	return (newcorrelationdata);
 }
 
-void checkdata(detectionformats::detection detectionobject, std::string testinfo) {
+void checkdata(detectionformats::detection detectionobject,
+		std::string testinfo) {
 	// check id
 	std::string detectionid = detectionobject.id;
 	std::string expectedid = std::string(ID);
@@ -103,39 +90,53 @@ void checkdata(detectionformats::detection detectionobject, std::string testinfo
 	ASSERT_EQ(depth, expecteddepth);
 
 	// check latitude error
-	double latitudeerror = detectionobject.hypocenter.latitudeerror;
-	double expectedlatitudeerror = LATITUDEERROR;
-	ASSERT_EQ(latitudeerror, expectedlatitudeerror);
+	if (std::isnan(detectionobject.hypocenter.latitudeerror) != true) {
+		double latitudeerror = detectionobject.hypocenter.latitudeerror;
+		double expectedlatitudeerror = LATITUDEERROR;
+		ASSERT_EQ(latitudeerror, expectedlatitudeerror);
+	}
 
 	// check longitude error
-	double longitdeerror = detectionobject.hypocenter.longitudeerror;
-	double expectedlongitudeerror = LONGITUDEERROR;
-	ASSERT_EQ(longitdeerror, expectedlongitudeerror);
+	if (std::isnan(detectionobject.hypocenter.longitudeerror) != true) {
+		double longitdeerror = detectionobject.hypocenter.longitudeerror;
+		double expectedlongitudeerror = LONGITUDEERROR;
+		ASSERT_EQ(longitdeerror, expectedlongitudeerror);
+	}
 
 	// check time error
-	double timeerror = detectionobject.hypocenter.timeerror;
-	double expectedtimeerror = TIMEERROR;
-	ASSERT_EQ(timeerror, expectedtimeerror);
+	if (std::isnan(detectionobject.hypocenter.timeerror) != true) {
+		double timeerror = detectionobject.hypocenter.timeerror;
+		double expectedtimeerror = TIMEERROR;
+		ASSERT_EQ(timeerror, expectedtimeerror);
+	}
 
 	// check depth error
-	double deptherror = detectionobject.hypocenter.deptherror;
-	double expecteddeptherror = DEPTHERROR;
-	ASSERT_EQ(deptherror, expecteddeptherror);
+	if (std::isnan(detectionobject.hypocenter.deptherror) != true) {
+		double deptherror = detectionobject.hypocenter.deptherror;
+		double expecteddeptherror = DEPTHERROR;
+		ASSERT_EQ(deptherror, expecteddeptherror);
+	}
 
 	// check detectiontype
-	std::string detectiondetectiontype = detectionobject.detectiontype;
-	std::string expecteddetectiontype = std::string(DETECTIONTYPE);
-	ASSERT_STREQ(detectiondetectiontype.c_str(), expecteddetectiontype.c_str());
-
+	if (detectionobject.detectiontype.compare("") != true) {
+		std::string detectiondetectiontype = detectionobject.detectiontype;
+		std::string expecteddetectiontype = std::string(DETECTIONTYPE);
+		ASSERT_STREQ(detectiondetectiontype.c_str(),
+				expecteddetectiontype.c_str());
+	}
 	// check eventtype
-	std::string detectioneventtype = detectionobject.eventtype;
-	std::string expectedeventtype = std::string(EVENTTYPE);
-	ASSERT_STREQ(detectioneventtype.c_str(), expectedeventtype.c_str());
+	if (detectionobject.eventtype.compare("") != true) {
+		std::string detectioneventtype = detectionobject.eventtype;
+		std::string expectedeventtype = std::string(EVENTTYPE);
+		ASSERT_STREQ(detectioneventtype.c_str(), expectedeventtype.c_str());
+	}
 
 	// check bayes
-	double detectionbayes = detectionobject.bayes;
-	double expectedbayes = BAYES;
-	ASSERT_EQ(detectionbayes, expectedbayes);
+	if (std::isnan(detectionobject.bayes) != true) {
+		double detectionbayes = detectionobject.bayes;
+		double expectedbayes = BAYES;
+		ASSERT_EQ(detectionbayes, expectedbayes);
+	}
 
 	// check minimumdistance
 	double detectionminimumdistance = detectionobject.minimumdistance;
@@ -170,8 +171,8 @@ TEST(DetectionTest, WritesJSON) {
 
 	detectionobject.hypocenter.latitude = LATITUDE;
 	detectionobject.hypocenter.longitude = LONGITUDE;
-	detectionobject.hypocenter.time = detectionformats::ConvertISO8601ToEpochTime(
-			std::string(TIME));
+	detectionobject.hypocenter.time =
+			detectionformats::ConvertISO8601ToEpochTime(std::string(TIME));
 	detectionobject.hypocenter.depth = DEPTH;
 	detectionobject.hypocenter.latitudeerror = LATITUDEERROR;
 	detectionobject.hypocenter.longitudeerror = LONGITUDEERROR;
@@ -187,18 +188,19 @@ TEST(DetectionTest, WritesJSON) {
 
 	// data
 	detectionobject.pickdata = buildpickdata();
-	detectionobject.beamdata = buildbeamdata();
 	detectionobject.correlationdata = buildcorrleationdata();
 
 	// build json string
 	rapidjson::Document detectiondocument;
 	std::string detectionjson = detectionformats::ToJSONString(
-			detectionobject.tojson(detectiondocument, detectiondocument.GetAllocator()));
+			detectionobject.tojson(detectiondocument,
+					detectiondocument.GetAllocator()));
 
 	// read it back in
 	rapidjson::Document detectiondocument2;
 	detectionformats::detection detectionobject2(
-			detectionformats::FromJSONString(detectionjson, detectiondocument2));
+			detectionformats::FromJSONString(detectionjson,
+					detectiondocument2));
 
 	// check data values
 	checkdata(detectionobject2, "");
@@ -226,7 +228,7 @@ TEST(DetectionTest, Constructor) {
 			detectionformats::ConvertISO8601ToEpochTime(std::string(TIME)),
 			DEPTH, LATITUDEERROR, LONGITUDEERROR, TIMEERROR, DEPTHERROR,
 			std::string(DETECTIONTYPE), std::string(EVENTTYPE),
-			BAYES, MINIMUMDISTANCE, RMS, GAP, buildpickdata(), buildbeamdata(),
+			BAYES, MINIMUMDISTANCE, RMS, GAP, buildpickdata(),
 			buildcorrleationdata());
 
 	// check data values
@@ -240,8 +242,7 @@ TEST(DetectionTest, Constructor) {
 							std::string(TIME)), DEPTH, LATITUDEERROR,
 					LONGITUDEERROR, TIMEERROR, DEPTHERROR),
 			std::string(DETECTIONTYPE), std::string(EVENTTYPE), BAYES,
-			MINIMUMDISTANCE, RMS, GAP, buildpickdata(), buildbeamdata(),
-			buildcorrleationdata());
+			MINIMUMDISTANCE, RMS, GAP, buildpickdata(), buildcorrleationdata());
 
 	// check data values
 	checkdata(detectionobject_altc, "Tested Alternate Constructor");
@@ -256,7 +257,7 @@ TEST(DetectionTest, CopyConstructor) {
 			detectionformats::ConvertISO8601ToEpochTime(std::string(TIME)),
 			DEPTH, LATITUDEERROR, LONGITUDEERROR, TIMEERROR, DEPTHERROR,
 			std::string(DETECTIONTYPE), std::string(EVENTTYPE),
-			BAYES, MINIMUMDISTANCE, RMS, GAP, buildpickdata(), buildbeamdata(),
+			BAYES, MINIMUMDISTANCE, RMS, GAP, buildpickdata(),
 			buildcorrleationdata());
 
 	detectionformats::detection detectionobject(fromdetectionobject);
@@ -279,8 +280,8 @@ TEST(DetectionTest, Validate) {
 
 	detectionobject.hypocenter.latitude = LATITUDE;
 	detectionobject.hypocenter.longitude = LONGITUDE;
-	detectionobject.hypocenter.time = detectionformats::ConvertISO8601ToEpochTime(
-			std::string(TIME));
+	detectionobject.hypocenter.time =
+			detectionformats::ConvertISO8601ToEpochTime(std::string(TIME));
 	detectionobject.hypocenter.depth = DEPTH;
 	detectionobject.hypocenter.latitudeerror = LATITUDEERROR;
 	detectionobject.hypocenter.longitudeerror = LONGITUDEERROR;
@@ -296,7 +297,6 @@ TEST(DetectionTest, Validate) {
 
 	// data
 	detectionobject.pickdata = buildpickdata();
-	detectionobject.beamdata = buildbeamdata();
 	detectionobject.correlationdata = buildcorrleationdata();
 
 	// successful validation

--- a/cpp/tests/pick_unittest.cpp
+++ b/cpp/tests/pick_unittest.cpp
@@ -4,15 +4,14 @@
 #include <string>
 
 // test data
-#define PICKSTRING "{\"Type\":\"Pick\",\"ID\":\"12GFH48776857\",\"Site\":{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Onset\":\"questionable\",\"Picker\":\"manual\",\"Filter\":[{\"HighPass\":1.05,\"LowPass\":2.65},{\"HighPass\":2.10,\"LowPass\":3.58}],\"Amplitude\":{\"Amplitude\":21.5,\"Period\":2.65,\"SNR\":3.8},\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}"
-#define PICKSTRINGNOFILTER "{\"Type\":\"Pick\",\"ID\":\"12GFH48776857\",\"Site\":{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Onset\":\"questionable\",\"Picker\":\"manual\",\"Filter\":[],\"Amplitude\":{\"Amplitude\":21.5,\"Period\":2.65,\"SNR\":3.8},\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}"
+#define PICKSTRING "{\"Type\":\"Pick\",\"ID\":\"12GFH48776857\",\"Site\":{\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Onset\":\"questionable\",\"Picker\":\"manual\",\"Filter\":[{\"HighPass\":1.05,\"LowPass\":2.65},{\"HighPass\":2.10,\"LowPass\":3.58}],\"Amplitude\":{\"Amplitude\":21.5,\"Period\":2.65,\"SNR\":3.8},\"Beam\":{\"BackAzimuth\":2.65,\"Slowness\":1.44,\"PowerRatio\":12.18,\"BackAzimuthError\":3.8,\"SlownessError\":0.4,\"PowerRatioError\":0.557},\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}"
+#define PICKSTRINGNOFILTER "{\"Type\":\"Pick\",\"ID\":\"12GFH48776857\",\"Site\":{\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Phase\":\"P\",\"Polarity\":\"up\",\"Onset\":\"questionable\",\"Picker\":\"manual\",\"Filter\":[],\"Amplitude\":{\"Amplitude\":21.5,\"Period\":2.65,\"SNR\":3.8},\"Beam\":{\"BackAzimuth\":2.65,\"Slowness\":1.44,\"PowerRatio\":12.18,\"BackAzimuthError\":3.8,\"SlownessError\":0.4,\"PowerRatioError\":0.557},\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}"
 
 #define ID "12GFH48776857"
 #define STATION "BMN"
 #define CHANNEL "HHZ"
 #define NETWORK "LB"
 #define LOCATION "01"
-#define SITEID "BMN.HHZ.LB.01"
 #define AGENCYID "US"
 #define AUTHOR "TestAuthor"
 #define TIME "2015-12-28T21:32:24.017Z"
@@ -27,158 +26,231 @@
 #define AMPLITUDEVALUE 21.5
 #define PERIOD 2.65
 #define SNR 3.8
+#define BACKAZIMUTH 2.65
+#define BACKAZIMUTHERROR 3.8
+#define SLOWNESS 1.44
+#define SLOWNESSERROR 0.4
+#define POWERRATIO 12.18
+#define POWERRATIOERROR 0.557
 #define ASSOCPHASE "P"
 #define ASSOCDISTANCE 0.442559
 #define ASSOCAZIMUTH 0.418479
 #define ASSOCRESIDUAL -0.025393
 #define ASSOCSIGMA 0.086333
 
-void checkdata(detectionformats::pick pickobject, std::string testinfo)
-{
+void checkdata(detectionformats::pick pickobject, std::string testinfo) {
 	// check id
 	std::string pickid = pickobject.id;
 	std::string expectedid = std::string(ID);
-	ASSERT_STREQ(pickid.c_str(), expectedid.c_str()) << testinfo.c_str();
+	ASSERT_STREQ(pickid.c_str(), expectedid.c_str())<< testinfo.c_str();
 
 	// check station
 	std::string sitestation = pickobject.site.station;
 	std::string expectedstation = std::string(STATION);
-	ASSERT_STREQ(sitestation.c_str(), expectedstation.c_str()) << testinfo.c_str();
+	ASSERT_STREQ(sitestation.c_str(), expectedstation.c_str())<< testinfo.c_str();
 
 	// check channel
 	std::string sitechannel = pickobject.site.channel;
 	std::string expectedchannel = std::string(CHANNEL);
-	ASSERT_STREQ(sitechannel.c_str(), expectedchannel.c_str()) << testinfo.c_str();
+	ASSERT_STREQ(sitechannel.c_str(), expectedchannel.c_str())<< testinfo.c_str();
 
 	// check network
 	std::string sitenetwork = pickobject.site.network;
 	std::string expectednetwork = std::string(NETWORK);
-	ASSERT_STREQ(sitenetwork.c_str(), expectednetwork.c_str()) << testinfo.c_str();
+	ASSERT_STREQ(sitenetwork.c_str(), expectednetwork.c_str())<< testinfo.c_str();
 
 	// check location
 	std::string sitelocation = pickobject.site.location;
 	std::string expectedlocation = std::string(LOCATION);
-	ASSERT_STREQ(sitelocation.c_str(), expectedlocation.c_str()) << testinfo.c_str();
-
-	// check siteid
-	std::string sitesiteid = pickobject.site.siteid;
-	std::string expectedsiteid = std::string(SITEID);
-	ASSERT_STREQ(sitesiteid.c_str(), expectedsiteid.c_str()) << testinfo.c_str();
+	ASSERT_STREQ(sitelocation.c_str(), expectedlocation.c_str())<< testinfo.c_str();
 
 	// check agencyid
 	std::string sourceagencyid = pickobject.source.agencyid;
 	std::string expectedagencyid = std::string(AGENCYID);
-	ASSERT_STREQ(sourceagencyid.c_str(), expectedagencyid.c_str()) << testinfo.c_str();
+	ASSERT_STREQ(sourceagencyid.c_str(), expectedagencyid.c_str())<< testinfo.c_str();
 
 	// check author
 	std::string sourceauthor = pickobject.source.author;
 	std::string expectedauthor = std::string(AUTHOR);
-	ASSERT_STREQ(sourceauthor.c_str(), expectedauthor.c_str()) << testinfo.c_str();
+	ASSERT_STREQ(sourceauthor.c_str(), expectedauthor.c_str())<< testinfo.c_str();
 
 	// check time
 	double picktime = pickobject.time;
-	double expectedtime = detectionformats::ConvertISO8601ToEpochTime(std::string(TIME));
-	ASSERT_EQ(picktime, expectedtime) << testinfo.c_str();
+	double expectedtime = detectionformats::ConvertISO8601ToEpochTime(
+			std::string(TIME));
+	ASSERT_EQ(picktime, expectedtime)<< testinfo.c_str();
 
 	// check phase
-	std::string pickphase = pickobject.phase;
-	std::string expectedphase = std::string(PHASE);
-	ASSERT_STREQ(pickphase.c_str(), expectedphase.c_str()) << testinfo.c_str();
+	if (pickobject.phase.compare("") != true) {
+		std::string pickphase = pickobject.phase;
+		std::string expectedphase = std::string(PHASE);
+		ASSERT_STREQ(pickphase.c_str(), expectedphase.c_str())<< testinfo.c_str();
+	}
 
 	// check polarity
-	std::string pickpolarity = pickobject.polarity;
-	std::string expectedpolarity = std::string(POLARITY);
-	ASSERT_STREQ(pickpolarity.c_str(), expectedpolarity.c_str()) << testinfo.c_str();
+	if (pickobject.polarity.compare("") != true) {
+		std::string pickpolarity = pickobject.polarity;
+		std::string expectedpolarity = std::string(POLARITY);
+		ASSERT_STREQ(pickpolarity.c_str(), expectedpolarity.c_str())<< testinfo.c_str();
+	}
 
 	// check onset
-	std::string pickonset = pickobject.onset;
-	std::string expectedonset = std::string(ONSET);
-	ASSERT_STREQ(pickonset.c_str(), expectedonset.c_str()) << testinfo.c_str();
+	if (pickobject.onset.compare("") != true) {
+		std::string pickonset = pickobject.onset;
+		std::string expectedonset = std::string(ONSET);
+		ASSERT_STREQ(pickonset.c_str(), expectedonset.c_str())<< testinfo.c_str();
+	}
 
 	// check picker
-	std::string pickpicker = pickobject.picker;
-	std::string expectedpicker = std::string(PICKER);
-	ASSERT_STREQ(pickpicker.c_str(), expectedpicker.c_str()) << testinfo.c_str();
+	if (pickobject.picker.compare("") != true) {
+		std::string pickpicker = pickobject.picker;
+		std::string expectedpicker = std::string(PICKER);
+		ASSERT_STREQ(pickpicker.c_str(), expectedpicker.c_str())<< testinfo.c_str();
+	}
 
 	// filter
-	if (pickobject.filterdata.size() > 0)
-	{
+	if (pickobject.filterdata.size() > 0) {
 		// check lowpass
-		double filterlowpass = pickobject.filterdata[0].lowpass;
-		double expectedlowpass = LOWPASS;
-		ASSERT_EQ(filterlowpass, expectedlowpass) << testinfo.c_str();
+		if (std::isnan(pickobject.filterdata[0].lowpass) != true) {
+			double filterlowpass = pickobject.filterdata[0].lowpass;
+			double expectedlowpass = LOWPASS;
+			ASSERT_EQ(filterlowpass, expectedlowpass)<< testinfo.c_str();
+		}
 
 		// check highpass
-		double filterhighpass = pickobject.filterdata[0].highpass;
-		double expectedhighpass = HIGHPASS;
-		ASSERT_EQ(filterhighpass, expectedhighpass) << testinfo.c_str();
+		if (std::isnan(pickobject.filterdata[0].highpass) != true) {
+			double filterhighpass = pickobject.filterdata[0].highpass;
+			double expectedhighpass = HIGHPASS;
+			ASSERT_EQ(filterhighpass, expectedhighpass)<< testinfo.c_str();
+		}
 
-		if (pickobject.filterdata.size() > 1)
-		{
+		if (pickobject.filterdata.size() > 1) {
 			// check lowpass2
-			double filterlowpass2 = pickobject.filterdata[1].lowpass;
-			double expectedlowpass2 = LOWPASS2;
-			ASSERT_EQ(filterlowpass2, expectedlowpass2) << testinfo.c_str();
+			if (std::isnan(pickobject.filterdata[1].lowpass) != true) {
+				double filterlowpass2 = pickobject.filterdata[1].lowpass;
+				double expectedlowpass2 = LOWPASS2;
+				ASSERT_EQ(filterlowpass2, expectedlowpass2)<< testinfo.c_str();
+			}
 
 			// check highpass2
-			double filterhighpass2 = pickobject.filterdata[1].highpass;
-			double expectedhighpass2 = HIGHPASS2;
-			ASSERT_EQ(filterhighpass2, expectedhighpass2) << testinfo.c_str();
+			if (std::isnan(pickobject.filterdata[1].highpass) != true) {
+				double filterhighpass2 = pickobject.filterdata[1].highpass;
+				double expectedhighpass2 = HIGHPASS2;
+				ASSERT_EQ(filterhighpass2, expectedhighpass2)<< testinfo.c_str();
+			}
 		}
 	}
 
-	// check period
-	double amplitudeperiod = pickobject.amplitude.period;
-	double expectedperiod = PERIOD;
-	ASSERT_EQ(amplitudeperiod, expectedperiod) << testinfo.c_str();
+	// amplitude
+	if (pickobject.amplitude.isempty() == false) {
+		// check period
+		if (std::isnan(pickobject.amplitude.period) != true) {
+			double amplitudeperiod = pickobject.amplitude.period;
+			double expectedperiod = PERIOD;
+			ASSERT_EQ(amplitudeperiod, expectedperiod)<< testinfo.c_str();
+		}
+		// check amplitude
+		if (std::isnan(pickobject.amplitude.ampvalue) != true) {
+			double amplitudeamplitude = pickobject.amplitude.ampvalue;
+			double expectedamplitude = AMPLITUDEVALUE;
+			ASSERT_EQ(amplitudeamplitude, expectedamplitude)<< testinfo.c_str();
+		}
+		// check snr
+		if (std::isnan(pickobject.amplitude.snr) != true) {
+			double amplitudesnr = pickobject.amplitude.snr;
+			double expectedsnr = SNR;
+			ASSERT_EQ(amplitudesnr, expectedsnr)<< testinfo.c_str();
+		}
+	}
 
-	// check amplitude
-	double amplitudeamplitude = pickobject.amplitude.ampvalue;
-	double expectedamplitude = AMPLITUDEVALUE;
-	ASSERT_EQ(amplitudeamplitude, expectedamplitude) << testinfo.c_str();
+	// beam
+	if (pickobject.beam.isempty() == false) {
 
-	// check snr
-	double amplitudesnr = pickobject.amplitude.snr;
-	double expectedsnr = SNR;
-	ASSERT_EQ(amplitudesnr, expectedsnr) << testinfo.c_str();
+		// check backazimuth
+		double beambackazimuth = pickobject.beam.backazimuth;
+		double expectedbackazimuth = BACKAZIMUTH;
+		ASSERT_EQ(beambackazimuth, expectedbackazimuth);
 
-	// check phase
-	std::string associatedphase = pickobject.associationinfo.phase;
-	std::string expectedassociatedphase = std::string(ASSOCPHASE);
-	ASSERT_STREQ(associatedphase.c_str(), expectedassociatedphase.c_str()) << testinfo.c_str();
+		// check backazimutherror
+		if (std::isnan(pickobject.beam.backazimutherror) != true) {
+			double beambackazimutherror = pickobject.beam.backazimutherror;
+			double expectedbackazimutherror = BACKAZIMUTHERROR;
+			ASSERT_EQ(beambackazimutherror, expectedbackazimutherror);
+		}
+		// check slowness
+		double beamslowness = pickobject.beam.slowness;
+		double expectedslowness = SLOWNESS;
+		ASSERT_EQ(beamslowness, expectedslowness);
 
-	// check distance
-	double associateddistance = pickobject.associationinfo.distance;
-	double expecteddistance = ASSOCDISTANCE;
-	ASSERT_EQ(associateddistance, expecteddistance) << testinfo.c_str();
+		// check slownesserror
+		if (std::isnan(pickobject.beam.slownesserror) != true) {
+			double beamslownesserrorr = pickobject.beam.slownesserror;
+			double expectedslownesserror = SLOWNESSERROR;
+			ASSERT_EQ(beamslownesserrorr, expectedslownesserror);
+		}
+		// check powerratio
+		if (std::isnan(pickobject.beam.powerratio) != true) {
+			double beampowerratio = pickobject.beam.powerratio;
+			double expectedpowerratio = POWERRATIO;
+			ASSERT_EQ(beampowerratio, expectedpowerratio);
+		}
 
-	// check azimuth
-	double associatedazimuth = pickobject.associationinfo.azimuth;
-	double expectedazimuth = ASSOCAZIMUTH;
-	ASSERT_EQ(associatedazimuth, expectedazimuth) << testinfo.c_str();
+		// check powerratioerror
+		if (std::isnan(pickobject.beam.powerratioerror) != true) {
+			double beampowerratioerrorr = pickobject.beam.powerratioerror;
+			double expectedpowerratioerror = POWERRATIOERROR;
+			ASSERT_EQ(beampowerratioerrorr, expectedpowerratioerror);
+		}
+	}
 
-	// check residual
-	double associatedresidual = pickobject.associationinfo.residual;
-	double expectedresidual = ASSOCRESIDUAL;
-	ASSERT_EQ(associatedresidual, expectedresidual) << testinfo.c_str();
+	// associationinfo
+	if (pickobject.associationinfo.isempty() == false) {
 
-	// check sigma
-	double associatedsigma = pickobject.associationinfo.sigma;
-	double expectedsigma = ASSOCSIGMA;
-	ASSERT_EQ(associatedsigma, expectedsigma) << testinfo.c_str();
+		// check phase
+		if (pickobject.associationinfo.phase.compare("") != true) {
+			std::string associatedphase = pickobject.associationinfo.phase;
+			std::string expectedassociatedphase = std::string(ASSOCPHASE);
+			ASSERT_STREQ(associatedphase.c_str(), expectedassociatedphase.c_str())<< testinfo.c_str();
+		}
+		// check distance
+		if (std::isnan(pickobject.associationinfo.distance) != true) {
+			double associateddistance = pickobject.associationinfo.distance;
+			double expecteddistance = ASSOCDISTANCE;
+			ASSERT_EQ(associateddistance, expecteddistance)<< testinfo.c_str();
+		}
+
+		// check azimuth
+		if (std::isnan(pickobject.associationinfo.azimuth) != true) {
+			double associatedazimuth = pickobject.associationinfo.azimuth;
+			double expectedazimuth = ASSOCAZIMUTH;
+			ASSERT_EQ(associatedazimuth, expectedazimuth)<< testinfo.c_str();
+		}
+
+		// check residual
+		if (std::isnan(pickobject.associationinfo.residual) != true) {
+			double associatedresidual = pickobject.associationinfo.residual;
+			double expectedresidual = ASSOCRESIDUAL;
+			ASSERT_EQ(associatedresidual, expectedresidual)<< testinfo.c_str();
+		}
+
+		// check sigma
+		if (std::isnan(pickobject.associationinfo.sigma) != true) {
+			double associatedsigma = pickobject.associationinfo.sigma;
+			double expectedsigma = ASSOCSIGMA;
+			ASSERT_EQ(associatedsigma, expectedsigma)<< testinfo.c_str();
+		}
+	}
 }
 
 // tests to see if pick can successfully
 // write json output
-TEST(PickTest, WritesJSON)
-{
+TEST(PickTest, WritesJSON) {
 	detectionformats::pick pickobject;
 
 	// build pick object
 	pickobject.id = std::string(ID);
 
 	// site subobject
-	pickobject.site.siteid = std::string(SITEID);
 	pickobject.site.station = std::string(STATION);
 	pickobject.site.channel = std::string(CHANNEL);
 	pickobject.site.network = std::string(NETWORK);
@@ -188,7 +260,8 @@ TEST(PickTest, WritesJSON)
 	pickobject.source.agencyid = std::string(AGENCYID);
 	pickobject.source.author = std::string(AUTHOR);
 
-	pickobject.time = detectionformats::ConvertISO8601ToEpochTime(std::string(TIME));
+	pickobject.time = detectionformats::ConvertISO8601ToEpochTime(
+			std::string(TIME));
 	pickobject.phase = std::string(PHASE);
 	pickobject.polarity = std::string(POLARITY);
 	pickobject.onset = std::string(ONSET);
@@ -210,6 +283,14 @@ TEST(PickTest, WritesJSON)
 	pickobject.amplitude.period = PERIOD;
 	pickobject.amplitude.snr = SNR;
 
+	// beam
+	pickobject.beam.backazimuth = BACKAZIMUTH;
+	pickobject.beam.backazimutherror = BACKAZIMUTHERROR;
+	pickobject.beam.slowness = SLOWNESS;
+	pickobject.beam.slownesserror = SLOWNESSERROR;
+	pickobject.beam.powerratio = POWERRATIO;
+	pickobject.beam.powerratioerror = POWERRATIOERROR;
+
 	// association subobject
 	pickobject.associationinfo.phase = std::string(ASSOCPHASE);
 	pickobject.associationinfo.distance = ASSOCDISTANCE;
@@ -219,25 +300,25 @@ TEST(PickTest, WritesJSON)
 
 	// build json string
 	rapidjson::Document pickdocument;
-	std::string pickjson = detectionformats::ToJSONString(pickobject.tojson(pickdocument, pickdocument.GetAllocator()));
+	std::string pickjson = detectionformats::ToJSONString(
+			pickobject.tojson(pickdocument, pickdocument.GetAllocator()));
 
-    // read it back in
-    rapidjson::Document pickdocument2;
-    detectionformats::pick pickobject2(detectionformats::FromJSONString(pickjson, pickdocument2));
+	// read it back in
+	rapidjson::Document pickdocument2;
+	detectionformats::pick pickobject2(
+			detectionformats::FromJSONString(pickjson, pickdocument2));
 
-    // check data values
-    checkdata(pickobject2, "");
+	// check data values
+	checkdata(pickobject2, "");
 }
 
-TEST(PickTest, WritesJSONNoFilter)
-{
+TEST(PickTest, WritesJSONNoFilter) {
 	detectionformats::pick pickobject;
 
 	// build pick object
 	pickobject.id = std::string(ID);
 
 	// site subobject
-	pickobject.site.siteid = std::string(SITEID);
 	pickobject.site.station = std::string(STATION);
 	pickobject.site.channel = std::string(CHANNEL);
 	pickobject.site.network = std::string(NETWORK);
@@ -247,7 +328,8 @@ TEST(PickTest, WritesJSONNoFilter)
 	pickobject.source.agencyid = std::string(AGENCYID);
 	pickobject.source.author = std::string(AUTHOR);
 
-	pickobject.time = detectionformats::ConvertISO8601ToEpochTime(std::string(TIME));
+	pickobject.time = detectionformats::ConvertISO8601ToEpochTime(
+			std::string(TIME));
 	pickobject.phase = std::string(PHASE);
 	pickobject.polarity = std::string(POLARITY);
 	pickobject.onset = std::string(ONSET);
@@ -260,6 +342,14 @@ TEST(PickTest, WritesJSONNoFilter)
 	pickobject.amplitude.period = PERIOD;
 	pickobject.amplitude.snr = SNR;
 
+	// beam
+	pickobject.beam.backazimuth = BACKAZIMUTH;
+	pickobject.beam.backazimutherror = BACKAZIMUTHERROR;
+	pickobject.beam.slowness = SLOWNESS;
+	pickobject.beam.slownesserror = SLOWNESSERROR;
+	pickobject.beam.powerratio = POWERRATIO;
+	pickobject.beam.powerratioerror = POWERRATIOERROR;
+
 	// association subobject
 	pickobject.associationinfo.phase = std::string(ASSOCPHASE);
 	pickobject.associationinfo.distance = ASSOCDISTANCE;
@@ -269,23 +359,26 @@ TEST(PickTest, WritesJSONNoFilter)
 
 	// build json string
 	rapidjson::Document pickdocument;
-	std::string pickjson = detectionformats::ToJSONString(pickobject.tojson(pickdocument, pickdocument.GetAllocator()));
+	std::string pickjson = detectionformats::ToJSONString(
+			pickobject.tojson(pickdocument, pickdocument.GetAllocator()));
 
-    // read it back in
-    rapidjson::Document pickdocument2;
-    detectionformats::pick pickobject2(detectionformats::FromJSONString(pickjson, pickdocument2));
+	// read it back in
+	rapidjson::Document pickdocument2;
+	detectionformats::pick pickobject2(
+			detectionformats::FromJSONString(pickjson, pickdocument2));
 
-    // check data values
-    checkdata(pickobject2, "");
+	// check data values
+	checkdata(pickobject2, "");
 }
 
 // tests to see if pick can successfully
 // read json output
-TEST(PickTest, ReadsJSON)
-{
+TEST(PickTest, ReadsJSON) {
 	// build pick object
 	rapidjson::Document pickdocument;
-	detectionformats::pick pickobject(detectionformats::FromJSONString(std::string(PICKSTRING), pickdocument));
+	detectionformats::pick pickobject(
+			detectionformats::FromJSONString(std::string(PICKSTRING),
+					pickdocument));
 
 	// check data values
 	checkdata(pickobject, "");
@@ -293,11 +386,12 @@ TEST(PickTest, ReadsJSON)
 
 // tests to see if pick can successfully
 // read json output
-TEST(PickTest, ReadsJSONNoFlter)
-{
+TEST(PickTest, ReadsJSONNoFilter) {
 	// build pick object
 	rapidjson::Document pickdocument;
-	detectionformats::pick pickobject(detectionformats::FromJSONString(std::string(PICKSTRINGNOFILTER), pickdocument));
+	detectionformats::pick pickobject(
+			detectionformats::FromJSONString(std::string(PICKSTRINGNOFILTER),
+					pickdocument));
 
 	// check data values
 	checkdata(pickobject, "");
@@ -305,12 +399,18 @@ TEST(PickTest, ReadsJSONNoFlter)
 
 // tests to see if pick can successfully
 // be constructed
-TEST(PickTest, Constructor)
-{
+TEST(PickTest, Constructor) {
 	// use constructor
-	detectionformats::pick pickobject(std::string(ID), std::string(SITEID), std::string(STATION), std::string(CHANNEL), std::string(NETWORK), std::string(LOCATION), detectionformats::ConvertISO8601ToEpochTime(std::string(TIME)),
-		std::string(AGENCYID), std::string(AUTHOR), std::string(PHASE), std::string(POLARITY), std::string(ONSET), std::string(PICKER), HIGHPASS, LOWPASS, AMPLITUDEVALUE, PERIOD, SNR, std::string(ASSOCPHASE), ASSOCDISTANCE,
-		ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
+	detectionformats::pick pickobject(std::string(ID), std::string(STATION),
+			std::string(CHANNEL), std::string(NETWORK), std::string(LOCATION),
+			detectionformats::ConvertISO8601ToEpochTime(std::string(TIME)),
+			std::string(AGENCYID), std::string(AUTHOR), std::string(PHASE),
+			std::string(POLARITY), std::string(ONSET), std::string(PICKER),
+			HIGHPASS, LOWPASS, AMPLITUDEVALUE, PERIOD, SNR, BACKAZIMUTH,
+			BACKAZIMUTHERROR, SLOWNESS,
+			SLOWNESSERROR, POWERRATIO, POWERRATIOERROR, std::string(ASSOCPHASE),
+			ASSOCDISTANCE,
+			ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
 
 	// check data values
 	checkdata(pickobject, "Tested Constructor");
@@ -319,9 +419,19 @@ TEST(PickTest, Constructor)
 	std::vector<detectionformats::filter> newfilterdata;
 	newfilterdata.push_back(detectionformats::filter(HIGHPASS, LOWPASS));
 
-	detectionformats::pick pickobject_altc(std::string(ID), detectionformats::site(std::string(SITEID), std::string(STATION), std::string(CHANNEL), std::string(NETWORK), std::string(LOCATION)), detectionformats::ConvertISO8601ToEpochTime(std::string(TIME)),
-		detectionformats::source(std::string(AGENCYID), std::string(AUTHOR)), std::string(PHASE), std::string(POLARITY), std::string(ONSET), std::string(PICKER), newfilterdata,
-		detectionformats::amplitude(AMPLITUDEVALUE, PERIOD, SNR), detectionformats::associated(std::string(ASSOCPHASE), ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA));
+	detectionformats::pick pickobject_altc(std::string(ID),
+			detectionformats::site(std::string(STATION), std::string(CHANNEL),
+					std::string(NETWORK), std::string(LOCATION)),
+			detectionformats::ConvertISO8601ToEpochTime(std::string(TIME)),
+			detectionformats::source(std::string(AGENCYID),
+					std::string(AUTHOR)), std::string(PHASE),
+			std::string(POLARITY), std::string(ONSET), std::string(PICKER),
+			newfilterdata,
+			detectionformats::amplitude(AMPLITUDEVALUE, PERIOD, SNR),
+			detectionformats::beam(BACKAZIMUTH, BACKAZIMUTHERROR, SLOWNESS,
+			SLOWNESSERROR, POWERRATIO, POWERRATIOERROR),
+			detectionformats::associated(std::string(ASSOCPHASE), ASSOCDISTANCE,
+			ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA));
 
 	// check data values
 	checkdata(pickobject_altc, "Tested alternate constructor");
@@ -329,12 +439,18 @@ TEST(PickTest, Constructor)
 
 // tests to see if pick can successfully
 // be copy constructed
-TEST(PickTest, CopyConstructor)
-{
+TEST(PickTest, CopyConstructor) {
 	// use constructor
-	detectionformats::pick frompickobject(std::string(ID), std::string(SITEID), std::string(STATION), std::string(CHANNEL), std::string(NETWORK), std::string(LOCATION), detectionformats::ConvertISO8601ToEpochTime(std::string(TIME)),
-		std::string(AGENCYID), std::string(AUTHOR), std::string(PHASE), std::string(POLARITY), std::string(ONSET), std::string(PICKER), HIGHPASS, LOWPASS, AMPLITUDEVALUE, PERIOD, SNR, std::string(ASSOCPHASE), ASSOCDISTANCE,
-		ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
+	detectionformats::pick frompickobject(std::string(ID), std::string(STATION),
+			std::string(CHANNEL), std::string(NETWORK), std::string(LOCATION),
+			detectionformats::ConvertISO8601ToEpochTime(std::string(TIME)),
+			std::string(AGENCYID), std::string(AUTHOR), std::string(PHASE),
+			std::string(POLARITY), std::string(ONSET), std::string(PICKER),
+			HIGHPASS, LOWPASS, AMPLITUDEVALUE, PERIOD, SNR, BACKAZIMUTH,
+			BACKAZIMUTHERROR, SLOWNESS,
+			SLOWNESSERROR, POWERRATIO, POWERRATIOERROR, std::string(ASSOCPHASE),
+			ASSOCDISTANCE,
+			ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
 
 	detectionformats::pick pickobject(frompickobject);
 
@@ -344,15 +460,13 @@ TEST(PickTest, CopyConstructor)
 
 // tests to see if pick can successfully
 // validate
-TEST(PickTest, Validate)
-{
+TEST(PickTest, Validate) {
 	detectionformats::pick pickobject;
 
 	// build pick object
 	pickobject.id = std::string(ID);
 
 	// site subobject
-	pickobject.site.siteid = std::string(SITEID);
 	pickobject.site.station = std::string(STATION);
 	pickobject.site.channel = std::string(CHANNEL);
 	pickobject.site.network = std::string(NETWORK);
@@ -362,7 +476,8 @@ TEST(PickTest, Validate)
 	pickobject.source.agencyid = std::string(AGENCYID);
 	pickobject.source.author = std::string(AUTHOR);
 
-	pickobject.time = detectionformats::ConvertISO8601ToEpochTime(std::string(TIME));
+	pickobject.time = detectionformats::ConvertISO8601ToEpochTime(
+			std::string(TIME));
 	pickobject.phase = std::string(PHASE);
 	pickobject.polarity = std::string(POLARITY);
 	pickobject.onset = std::string(ONSET);
@@ -379,6 +494,14 @@ TEST(PickTest, Validate)
 	pickobject.amplitude.period = PERIOD;
 	pickobject.amplitude.snr = SNR;
 
+	// beam
+	pickobject.beam.backazimuth = BACKAZIMUTH;
+	pickobject.beam.backazimutherror = BACKAZIMUTHERROR;
+	pickobject.beam.slowness = SLOWNESS;
+	pickobject.beam.slownesserror = SLOWNESSERROR;
+	pickobject.beam.powerratio = POWERRATIO;
+	pickobject.beam.powerratioerror = POWERRATIOERROR;
+
 	// association subobject
 	pickobject.associationinfo.phase = std::string(ASSOCPHASE);
 	pickobject.associationinfo.distance = ASSOCDISTANCE;
@@ -390,23 +513,20 @@ TEST(PickTest, Validate)
 	bool result = pickobject.isvalid();
 
 	// check return code
-	ASSERT_EQ(result, true) << "Tested for successful validation.";
+	ASSERT_EQ(result, true)<< "Tested for successful validation.";
 
 	// build bad pick object
 	detectionformats::pick badpickobject;
 	badpickobject.id = "";
 
 	result = false;
-	try
-	{
+	try {
 		// call validation
 		result = badpickobject.isvalid();
-	}
-	catch (const std::exception &)
-	{
+	} catch (const std::exception &) {
 		// don't care what the exception was
 	}
 
 	// check return code
-	ASSERT_EQ(result, false) << "Tested for unsuccessful validation.";
+	ASSERT_EQ(result, false)<< "Tested for unsuccessful validation.";
 }

--- a/cpp/tests/site_unittest.cpp
+++ b/cpp/tests/site_unittest.cpp
@@ -4,15 +4,13 @@
 #include <string>
 
 // test data
-#define SITESTRING "{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"}"
+#define SITESTRING "{\"Station\":\"BMN\",\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"}"
 #define STATION "BMN"
 #define CHANNEL "HHZ"
 #define NETWORK "LB"
 #define LOCATION "01"
-#define SITEID "BMN.HHZ.LB.01"
 
-void checkdata(detectionformats::site siteobject, std::string testinfo)
-{
+void checkdata(detectionformats::site siteobject, std::string testinfo) {
 	// check station
 	std::string sitestation = siteobject.station;
 	std::string expectedstation = std::string(STATION);
@@ -32,21 +30,14 @@ void checkdata(detectionformats::site siteobject, std::string testinfo)
 	std::string sitelocation = siteobject.location;
 	std::string expectedlocation = std::string(LOCATION);
 	ASSERT_STREQ(sitelocation.c_str(), expectedlocation.c_str());
-
-	// check siteid
-	std::string sitesiteid = siteobject.siteid;
-	std::string expectedsiteid = std::string(SITEID);
-	ASSERT_STREQ(sitesiteid.c_str(), expectedsiteid.c_str());
 }
 
 // tests to see if site can successfully
 // write json output
-TEST(SiteTest, WritesJSON)
-{
+TEST(SiteTest, WritesJSON) {
 	detectionformats::site siteobject;
 
 	// build site object
-	siteobject.siteid = std::string(SITEID);
 	siteobject.station = std::string(STATION);
 	siteobject.channel = std::string(CHANNEL);
 	siteobject.network = std::string(NETWORK);
@@ -54,23 +45,26 @@ TEST(SiteTest, WritesJSON)
 
 	// build json string
 	rapidjson::Document sitedocument;
-	std::string sitejson = detectionformats::ToJSONString(siteobject.tojson(sitedocument, sitedocument.GetAllocator()));
+	std::string sitejson = detectionformats::ToJSONString(
+			siteobject.tojson(sitedocument, sitedocument.GetAllocator()));
 
-    // read it back in
-    rapidjson::Document sitedocument2;
-    detectionformats::site siteobject2(detectionformats::FromJSONString(sitejson, sitedocument2));
-    
-    // check data values
-    checkdata(siteobject2, "");
+	// read it back in
+	rapidjson::Document sitedocument2;
+	detectionformats::site siteobject2(
+			detectionformats::FromJSONString(sitejson, sitedocument2));
+
+	// check data values
+	checkdata(siteobject2, "");
 }
 
 // tests to see if site can successfully
 // read json output
-TEST(SiteTest, ReadsJSON)
-{
+TEST(SiteTest, ReadsJSON) {
 	// build site object
 	rapidjson::Document sitedocument;
-	detectionformats::site siteobject(detectionformats::FromJSONString(std::string(SITESTRING), sitedocument));
+	detectionformats::site siteobject(
+			detectionformats::FromJSONString(std::string(SITESTRING),
+					sitedocument));
 
 	// check data values
 	checkdata(siteobject, "");
@@ -78,10 +72,9 @@ TEST(SiteTest, ReadsJSON)
 
 // tests to see if site can successfully
 // be constructed
-TEST(SiteTest, Constructor)
-{
+TEST(SiteTest, Constructor) {
 	// use constructor
-	detectionformats::site siteobject(SITEID, STATION, CHANNEL, NETWORK, LOCATION);
+	detectionformats::site siteobject(STATION, CHANNEL, NETWORK, LOCATION);
 
 	// check data values
 	checkdata(siteobject, "");
@@ -89,12 +82,10 @@ TEST(SiteTest, Constructor)
 
 // tests to see if site can successfully
 // validate
-TEST(SiteTest, Validate)
-{
+TEST(SiteTest, Validate) {
 	detectionformats::site siteobject;
 
 	// build site object
-	siteobject.siteid = std::string(SITEID);
 	siteobject.station = std::string(STATION);
 	siteobject.channel = std::string(CHANNEL);
 	siteobject.network = std::string(NETWORK);
@@ -104,24 +95,20 @@ TEST(SiteTest, Validate)
 	bool result = siteobject.isvalid();
 
 	// check return code
-	ASSERT_EQ(result, true) << "Tested for successful validation.";
+	ASSERT_EQ(result, true)<< "Tested for successful validation.";
 
 	// build bad site object
 	detectionformats::site badsiteobject;
-	badsiteobject.siteid = std::string(SITEID);
 	badsiteobject.location = std::string(LOCATION);
 
 	result = false;
-	try
-	{
+	try {
 		// call validation
 		result = badsiteobject.isvalid();
-	}
-	catch (const std::exception &)
-	{
+	} catch (const std::exception &) {
 		// don't care what the exception was
 	}
 
 	// check return code
-	ASSERT_EQ(result, false) << "Tested for unsuccessful validation.";
+	ASSERT_EQ(result, false)<< "Tested for unsuccessful validation.";
 }

--- a/format-docs/Associated.md
+++ b/format-docs/Associated.md
@@ -3,7 +3,7 @@
 ## Description
 
 The Associated object is an object designed to encode information provided when
-a [Pick](Pick.md), [Beam](Beam.md), or [Correlation](Correlation.md) is included
+a [Pick](Pick.md) or [Correlation](Correlation.md) is included
 as supporting data in a [Detection](Detection.md).  Associated uses the
 [JSON standard](http://www.json.org).
 

--- a/format-docs/Beam.md
+++ b/format-docs/Beam.md
@@ -1,48 +1,24 @@
-# Beam Format Specification
+# Beam Object Specification
 
 ## Description
 
-Beam is a format designed to encode the basic information of an unassociated
-waveform beam.  PickJSON uses the [JSON standard](http://www.json.org).
+The Beam object is an object designed to encode waveform beam information
+that may or may not be part of the [Pick](Pick.md) Format.  Beam uses the
+[JSON standard](http://www.json.org).
 
 ## Usage
-Beam is intended for use in seismic data messaging between seismic applications
-and organizations.
+The Beam object is intended for use as part of the [Pick](Pick.md) Format
+in seismic data messaging between seismic applications and organizations.
 
 ## Output
 ```json
-    {
-      "Type"      : "Beam",
-      "ID"        : String,
-      "Site"      :
-      {
-         "SiteID"   : String,
-         "Station"  : String,
-         "Channel"  : String,
-         "Network"  : String,
-         "Location" : String
-      },
-      "Source"      :
-      {
-         "AgencyID" : String,
-         "Author"   : String
-      },
-      "StartTime"        : ISO8601,
-      "EndTime"          : ISO8601,
+    {    
       "BackAzimuth"      : Number,
       "BackAzimuthError" : Number,
       "Slowness"         : Number,
       "SlownessError"    : Number,
       "PowerRatio"       : Number,
       "PowerRatioError"  : Number,      
-      "AssociationInfo"  :
-      {
-         "Phase"    : String,
-         "Distance" : Number,
-         "Azimuth"  : Number,
-         "Residual" : Number,
-         "Sigma"    : Number
-      }
     }
 ```
 
@@ -50,18 +26,8 @@ and organizations.
 **Required Values:**
 
 These are the values **required** to define a beam.
-* Type - A string that identifies this message as a beam.
-* ID - A string containing an unique identifier for this beam.
-* Site - An object containing the station the beam was made at, see
-[Site](Site.md).
-* Source - An object containing the source of the beam, see [Source](Source.md).
-* StartTime - A string containing the UTC start time of the beam, in the ISO8601
-format `YYYY-MM-DDTHH:MM:SS.SSSZ`.
-* EndTime - A string containing the UTC end time of the beam, in the ISO8601
-format `YYYY-MM-DDTHH:MM:SS.SSSZ`.
 * BackAzimuth - A decimal number containing the back azimuth.
 * Slowness - A decimal number containing the horizontal slowness.
-* PowerRatio - A decimal number containing the power.
 
 **Optional Values:**
 
@@ -69,7 +35,5 @@ The following are supplementary values that **may or may not** be provided by
 various algorithms.
 * BackAzimuthError - A decimal number containing the back azimuth error.
 * SlownessError - A decimal number containing the horizontal slowness error.
-* PowerRatioError - A decimal number containing the power error.
-* AssociationInfo - An object containing the association information if this
-beam is used as data in a [Detection](Detection.md), see
-[Association](Association.md).
+* PowerRatio - A decimal number containing the power ratio.
+* PowerRatioError - A decimal number containing the power ratio error.

--- a/format-docs/Correlation.md
+++ b/format-docs/Correlation.md
@@ -16,7 +16,6 @@ applications and organizations.
       "ID"        : String,
       "Site"      :
       {
-         "SiteID"   : String,
          "Station"  : String,
          "Channel"  : String,
          "Network"  : String,

--- a/format-docs/Detection.md
+++ b/format-docs/Detection.md
@@ -36,7 +36,7 @@ applications.
       "MinimumDistance" : Number,
       "RMS"             : Number,
       "Gap"             : Number,
-      "Data"            : [PickJSON, BeamJSON, and / or CorrelationJSON Objects, ...]
+      "Data"            : [PickJSON and/or CorrelationJSON Objects, ...]
     }
 ```
 
@@ -57,6 +57,6 @@ Optional Values:
 * Bayes - A decimal number that identifies bayesian statistic for this Detection.
 * Sigma - A decimal number indicating the standard deviation of the hypocenter
 time measurement.
-* Data - An array of [Pick](Pick.md), [Beam](Beam.md), and / or
+* Data - An array of [Pick](Pick.md), and / or
 [Correlation](Correlation.md) objects used to generate this Detection.
 * MinimumDistance - The minimum distance to the closest station.

--- a/format-docs/Pick.md
+++ b/format-docs/Pick.md
@@ -15,10 +15,8 @@ applications and organizations.
     {
       "Type"      : "Pick",
       "ID"        : String,
-      "SiteID"    : String,
       "Site"      :
       {
-         "SiteID"    : String,
          "Station"   : String,
          "Channel"   : String,
          "Network"   : String,
@@ -40,6 +38,15 @@ applications and organizations.
          "Amplitude" : Number,
          "Period"    : Number,
          "SNR"       : Number
+      },
+      "Beam" :
+      {    
+        "BackAzimuth"      : Number,
+        "BackAzimuthError" : Number,
+        "Slowness"         : Number,
+        "SlownessError"    : Number,
+        "PowerRatio"       : Number,
+        "PowerRatioError"  : Number,      
       },
       "AssociationInfo" :
       {
@@ -80,6 +87,8 @@ was made, see
 [Filter](Filter.md).
 * Amplitude - An object containing the amplitude associated with the pick, see
 [Amplitude](Amplitude.md).
+* Beam - An object containing the waveform beam information associated with the
+pick, see [Beam](Beam.md).
 * AssociationInfo - An object containing the association information if this
 pick is used as data in a [Detection](Detection.md), see
 [Associated](Associated.md).

--- a/format-docs/README.md
+++ b/format-docs/README.md
@@ -4,8 +4,6 @@ various types of seismic event detections.
 ## Defined formats:
 * [Pick](Pick.md) Format - A format for unassociated picks from a
 waveform arrival time picking algorithm.
-* [Beam](Beam.md) Format  - A format for unassociated beams from seismic
-array beamforming algorithm.
 * [Correlation](Correlation.md) Format - A format to contain a seismic
 event detection made using a cross correlation algorithm.
 * [Detection](format-docs/Detection.md) Format - A format to contain a seismic
@@ -18,6 +16,8 @@ retraction made using an event detection algorithm.
 a hypocenter as part of a detection.
 * [Amplitude](Amplitude.md) Object - An object that contains information about
 an amplitude as part of a pick.
+* [Beam](Beam.md) Object  - An object that contains information about a waveform
+beam as part of a pick.
 * [Associated](Associated.md) Object - An object that contains associated
 information if a pick, beam, or correlation is included in an detection.
 * [Filter](Filter.md) Object - An object that contains filter information as

--- a/format-docs/Site.md
+++ b/format-docs/Site.md
@@ -14,7 +14,6 @@ applications and organizations.
 ## Output
 ```json
     {
-      "SiteID"    : String,
       "Station"   : String,
       "Channel"   : String,
       "Network"   : String,
@@ -27,11 +26,8 @@ applications and organizations.
 
 These are the values **required** to define a Site.
 
-* SiteID -  A unique string containing an unique identifier for this station
-usually formatted to contain the available station, channel, network, and/or
-location codes.
 * Station - A string the station code.
-* Site:Network - A string containing network code.
+* Network - A string containing network code.
 
 **Optional Values:**
 

--- a/java/src/gov/usgs/detectionformats/Beam.java
+++ b/java/src/gov/usgs/detectionformats/Beam.java
@@ -15,49 +15,12 @@ public class Beam implements DetectionInt {
 	/**
 	 * JSON Keys
 	 */
-	public static final String TYPE_KEY = "Type";
-	public static final String ID_KEY = "ID";
-	public static final String SITE_KEY = "Site";
-	public static final String SOURCE_KEY = "Source";
-	public static final String STARTTIME_KEY = "StartTime";
-	public static final String ENDTIME_KEY = "EndTime";
 	public static final String BACKAZIMUTH_KEY = "BackAzimuth";
 	public static final String SLOWNESS_KEY = "Slowness";
 	public static final String BACKAZIMUTHERROR_KEY = "BackAzimuthError";
 	public static final String POWERRATIO_KEY = "PowerRatio";
 	public static final String POWERRATIOERROR_KEY = "PowerRatioError";
 	public static final String SLOWNESSERROR_KEY = "SlownessError";
-	public static final String ASSOCIATIONINFO_KEY = "AssociationInfo";
-
-	/**
-	 * Required type identifier for this Beam
-	 */
-	private final String type;
-
-	/**
-	 * Required unique identifier for this Beam
-	 */
-	private final String id;
-
-	/**
-	 * Required site.
-	 */
-	private final Site site;
-
-	/**
-	 * Required source.
-	 */
-	private final Source source;
-
-	/**
-	 * Required starttime for this Beam
-	 */
-	private final Date startTime;
-
-	/**
-	 * Required endtime for this Beam
-	 */
-	private final Date endTime;
 
 	/**
 	 * Required Double containing the back azimuth
@@ -80,7 +43,7 @@ public class Beam implements DetectionInt {
 	private final Double slownessError;
 
 	/**
-	 * Required Double containing the powerRatio
+	 * Optional Double containing the powerRatio
 	 */
 	private final Double powerRatio;
 
@@ -90,108 +53,22 @@ public class Beam implements DetectionInt {
 	private final Double powerRatioError;
 
 	/**
-	 * Optional associated information.
-	 */
-	private final Associated associationInfo;
-
-	/**
 	 * The constructor for the Beam class. Initializes members to null values.
 	 */
 	public Beam() {
 
-		type = "Beam";
-		site = null;
-		source = null;
-		id = null;
-		startTime = null;
-		endTime = null;
 		backAzimuth = null;
 		backAzimuthError = null;
 		slowness = null;
 		slownessError = null;
 		powerRatio = null;
 		powerRatioError = null;
-		associationInfo = null;
-	}
-
-	/**
-	 * The advanced constructor for the Beam Class. Initializes members to
-	 * provided values.
-	 *
-	 * @param newID
-	 *            - A String containing the id to use
-	 * @param newSiteID
-	 *            - A String containing the siteid to use
-	 * @param newStation
-	 *            - A String containing the station to use
-	 * @param newChannel
-	 *            - A String containing the channel to use
-	 * @param newNetwork
-	 *            - A String containing the network to use
-	 * @param newLocation
-	 *            - A String containing the location to use
-	 * @param newAgencyID
-	 *            - A String containing the agencyid to use
-	 * @param newAuthor
-	 *            - A String containing the author to use
-	 * @param newStartTime
-	 *            - A Date containing the start time to use
-	 * @param newEndTime
-	 *            - A Date containing the end time to use
-	 * @param newBackAzimuth
-	 *            - A Double containing the back azimuth to use
-	 * @param newBackAzimutherror
-	 *            - A Double containing the back azimuth error to use, null to
-	 *            omit
-	 * @param newSlowness
-	 *            - A Double containing the slowness to use
-	 * @param newSlownessError
-	 *            - A Double containing the slowness error to use, null to omit
-	 * @param newPowerRatio
-	 *            - A Double containing the power ratio to use
-	 * @param newPowerRatioError
-	 *            - A Double containing the power ratio error to use, null to
-	 *            omit
-	 */
-	public Beam(String newID, String newSiteID, String newStation,
-			String newChannel, String newNetwork, String newLocation,
-			String newAgencyID, String newAuthor, Date newStartTime,
-			Date newEndTime, Double newBackAzimuth, Double newBackAzimutherror,
-			Double newSlowness, Double newSlownessError, Double newPowerRatio,
-			Double newPowerRatioError) {
-
-		this(newID,
-				new Site(newSiteID, newStation, newChannel, newNetwork,
-						newLocation),
-				new Source(newAgencyID, newAuthor), newStartTime, newEndTime,
-				newBackAzimuth, newBackAzimutherror, newSlowness,
-				newSlownessError, newPowerRatio, newPowerRatioError);
 	}
 
 	/**
 	 * The advanced constructor for the Beam class. Initializes members to
 	 * provided values.
 	 *
-	 * @param newID
-	 *            - A String containing the id to use
-	 * @param newSiteID
-	 *            - A String containing the siteid to use
-	 * @param newStation
-	 *            - A String containing the station to use
-	 * @param newChannel
-	 *            - A String containing the channel to use
-	 * @param newNetwork
-	 *            - A String containing the network to use
-	 * @param newLocation
-	 *            - A String containing the location to use
-	 * @param newAgencyID
-	 *            - A String containing the agencyid to use
-	 * @param newAuthor
-	 *            - A String containing the author to use
-	 * @param newStartTime
-	 *            - A Date containing the start time to use
-	 * @param newEndTime
-	 *            - A Date containing the end time to use
 	 * @param newBackAzimuth
 	 *            - A Double containing the back azimuth to use
 	 * @param newBackAzimutherror
@@ -202,135 +79,21 @@ public class Beam implements DetectionInt {
 	 * @param newSlownessError
 	 *            - A Double containing the slowness error to use, null to omit
 	 * @param newPowerRatio
-	 *            - A Double containing the power ratio to use
+	 *            - A Double containing the power ratio to use, null to omit
 	 * @param newPowerRatioError
 	 *            - A Double containing the power ratio error to use, null to
 	 *            omit
-	 * @param newAssociatedPhase
-	 *            - A std:string containing the associated phase to use, null to
-	 *            omit
-	 * @param newAssociatedDistance
-	 *            - A Double containing the associated distance to use, null to
-	 *            omit
-	 * @param newAssociatedAzimuth
-	 *            - A Double containing the associated azimuth to use, null to
-	 *            omit
-	 * @param newAssociatedResidual
-	 *            - A Double containing the associated residual to use, null to
-	 *            omit
-	 * @param newAssociatedSigma
-	 *            - A Double containing the associated sigma to use, null to
-	 *            omit
 	 */
-	public Beam(String newID, String newSiteID, String newStation,
-			String newChannel, String newNetwork, String newLocation,
-			String newAgencyID, String newAuthor, Date newStartTime,
-			Date newEndTime, Double newBackAzimuth, Double newBackAzimutherror,
-			Double newSlowness, Double newSlownessError, Double newPowerRatio,
-			Double newPowerRatioError, String newAssociatedPhase,
-			Double newAssociatedDistance, Double newAssociatedAzimuth,
-			Double newAssociatedResidual, Double newAssociatedSigma) {
-
-		this(newID,
-				new Site(newSiteID, newStation, newChannel, newNetwork,
-						newLocation),
-				new Source(newAgencyID, newAuthor), newStartTime, newEndTime,
-				newBackAzimuth, newBackAzimutherror, newSlowness,
-				newSlownessError, newPowerRatio, newPowerRatioError,
-				new Associated(newAssociatedPhase, newAssociatedDistance,
-						newAssociatedAzimuth, newAssociatedResidual,
-						newAssociatedSigma));
-	}
-
-	/**
-	 * The alternate advanced constructor for the Beam class. Initializes
-	 * members to provided values.
-	 *
-	 * @param newID
-	 *            - A String containing the id to use
-	 * @param newSite
-	 *            - A Site containing the site to use
-	 * @param newSource
-	 *            - A Source containing the source to use
-	 * @param newStartTime
-	 *            - A Date containing the start time to use
-	 * @param newEndTime
-	 *            - A Date containing the end time to use
-	 * @param newBackAzimuth
-	 *            - A Double containing the back azimuth to use
-	 * @param newBackAzimutherror
-	 *            - A Double containing the back azimuth error to use, null to
-	 *            omit
-	 * @param newPowerRatio
-	 *            - A Double containing the power ratio to use
-	 * @param newPowerRatioError
-	 *            - A Double containing the power ratio error to use, null to
-	 *            omit
-	 * @param newSlowness
-	 *            - A Double containing the slowness to use
-	 * @param newSlownessError
-	 *            - A Double containing the slowness error to use, null to omit
-	 */
-	public Beam(String newID, Site newSite, Source newSource, Date newStartTime,
-			Date newEndTime, Double newBackAzimuth, Double newBackAzimutherror,
+	public Beam(Double newBackAzimuth, Double newBackAzimutherror,
 			Double newSlowness, Double newSlownessError, Double newPowerRatio,
 			Double newPowerRatioError) {
 
-		this(newID, newSite, newSource, newStartTime, newEndTime,
-				newBackAzimuth, newBackAzimutherror, newSlowness,
-				newSlownessError, newPowerRatio, newPowerRatioError,
-				new Associated());
-	}
-
-	/**
-	 * The alternate advanced constructor for the Beam class. Initializes
-	 * members to provided values.
-	 *
-	 * @param newID
-	 *            - A String containing the id to use
-	 * @param newSite
-	 *            - A Site containing the site to use
-	 * @param newSource
-	 *            - A Source containing the source to use
-	 * @param newStartTime
-	 *            - A Date containing the start time to use
-	 * @param newEndTime
-	 *            - A Date containing the end time to use
-	 * @param newBackAzimuth
-	 *            - A Double containing the back azimuth to use
-	 * @param newBackAzimutherror
-	 *            - A Double containing the back azimuth error to use, null to
-	 *            omit
-	 * @param newSlowness
-	 *            - A Double containing the slowness to use
-	 * @param newSlownessError
-	 *            - A Double containing the slowness error to use, null to omit
-	 * @param newPowerRatio
-	 *            - A Double containing the power ratio to use
-	 * @param newPowerRatioError
-	 *            - A Double containing the power ratio error to use, null to
-	 *            omit
-	 * @param newAssociated
-	 *            - A Associated containing the associated to use, null to omit
-	 */
-	public Beam(String newID, Site newSite, Source newSource, Date newStartTime,
-			Date newEndTime, Double newBackAzimuth, Double newBackAzimutherror,
-			Double newSlowness, Double newSlownessError, Double newPowerRatio,
-			Double newPowerRatioError, Associated newAssociated) {
-
-		type = "Beam";
-		id = newID;
-		site = newSite;
-		source = newSource;
-		startTime = newStartTime;
-		endTime = newEndTime;
 		backAzimuth = newBackAzimuth;
 		backAzimuthError = newBackAzimutherror;
 		slowness = newSlowness;
 		slownessError = newSlownessError;
 		powerRatio = newPowerRatio;
 		powerRatioError = newPowerRatioError;
-		associationInfo = newAssociated;
 	}
 
 	/**
@@ -342,50 +105,6 @@ public class Beam implements DetectionInt {
 	public Beam(JSONObject newJSONObject) {
 
 		// Required values
-		// type
-		if (newJSONObject.containsKey(TYPE_KEY)) {
-			type = newJSONObject.get(TYPE_KEY).toString();
-		} else {
-			type = null;
-		}
-
-		// id
-		if (newJSONObject.containsKey(ID_KEY)) {
-			id = newJSONObject.get(ID_KEY).toString();
-		} else {
-			id = null;
-		}
-
-		// site
-		if (newJSONObject.containsKey(SITE_KEY)) {
-			site = new Site((JSONObject) newJSONObject.get(SITE_KEY));
-		} else {
-			site = null;
-		}
-
-		// source
-		if (newJSONObject.containsKey(SOURCE_KEY)) {
-			source = new Source((JSONObject) newJSONObject.get(SOURCE_KEY));
-		} else {
-			source = null;
-		}
-
-		// startTime
-		if (newJSONObject.containsKey(STARTTIME_KEY)) {
-			startTime = Utility
-					.getDate(newJSONObject.get(STARTTIME_KEY).toString());
-		} else {
-			startTime = null;
-		}
-
-		// endTime
-		if (newJSONObject.containsKey(ENDTIME_KEY)) {
-			endTime = Utility
-					.getDate(newJSONObject.get(ENDTIME_KEY).toString());
-		} else {
-			endTime = null;
-		}
-
 		// backAzimuth
 		if (newJSONObject.containsKey(BACKAZIMUTH_KEY)) {
 			backAzimuth = (double) newJSONObject.get(BACKAZIMUTH_KEY);
@@ -400,6 +119,7 @@ public class Beam implements DetectionInt {
 			slowness = null;
 		}
 
+		// Optional values
 		// powerRatio
 		if (newJSONObject.containsKey(POWERRATIO_KEY)) {
 			powerRatio = (double) newJSONObject.get(POWERRATIO_KEY);
@@ -407,7 +127,6 @@ public class Beam implements DetectionInt {
 			powerRatio = null;
 		}
 
-		// Optional values
 		// backAzimuthError
 		if (newJSONObject.containsKey(BACKAZIMUTHERROR_KEY)) {
 			backAzimuthError = (double) newJSONObject.get(BACKAZIMUTHERROR_KEY);
@@ -428,14 +147,6 @@ public class Beam implements DetectionInt {
 		} else {
 			powerRatioError = null;
 		}
-
-		// associated
-		if (newJSONObject.containsKey(ASSOCIATIONINFO_KEY)) {
-			associationInfo = new Associated(
-					(JSONObject) newJSONObject.get(ASSOCIATIONINFO_KEY));
-		} else {
-			associationInfo = null;
-		}
 	}
 
 	/**
@@ -449,49 +160,14 @@ public class Beam implements DetectionInt {
 
 		JSONObject newJSONObject = new JSONObject();
 
-		String jsonType = getType();
-		String jsonID = getID();
-		Site jsonSite = getSite();
-		Source jsonSource = getSource();
-		Date jsonStartTime = getStartTime();
-		Date jsonEndTime = getEndTime();
 		Double jsonBackAzimuth = getBackAzimuth();
 		Double jsonSlowness = getSlowness();
 		Double jsonPowerRatio = getPowerRatio();
 		Double jsonBackAzimuthError = getBackAzimuthError();
 		Double jsonSlownessError = getSlownessError();
 		Double jsonPowerRatioError = getPowerRatioError();
-		Associated jsonAssociationInfo = getAssociationInfo();
 
 		// Required values
-		// type
-		newJSONObject.put(TYPE_KEY, jsonType);
-
-		// id
-		if (jsonID != null) {
-			newJSONObject.put(ID_KEY, jsonID);
-		}
-
-		// site
-		if (jsonSite != null) {
-			newJSONObject.put(SITE_KEY, jsonSite.toJSON());
-		}
-
-		// source
-		if (jsonSource != null) {
-			newJSONObject.put(SOURCE_KEY, jsonSource.toJSON());
-		}
-
-		// startTime
-		if (jsonStartTime != null) {
-			newJSONObject.put(STARTTIME_KEY, Utility.formatDate(jsonStartTime));
-		}
-
-		// endTime
-		if (jsonEndTime != null) {
-			newJSONObject.put(ENDTIME_KEY, Utility.formatDate(jsonEndTime));
-		}
-
 		// backAzimuth
 		if (jsonBackAzimuth != null) {
 			newJSONObject.put(BACKAZIMUTH_KEY, jsonBackAzimuth);
@@ -502,12 +178,12 @@ public class Beam implements DetectionInt {
 			newJSONObject.put(SLOWNESS_KEY, jsonSlowness);
 		}
 
+		// Optional values
 		// powerRatio
 		if (jsonPowerRatio != null) {
 			newJSONObject.put(POWERRATIO_KEY, jsonPowerRatio);
 		}
 
-		// Optional values
 		// backAzimuthError
 		if (jsonBackAzimuthError != null) {
 			newJSONObject.put(BACKAZIMUTHERROR_KEY, jsonBackAzimuthError);
@@ -522,11 +198,6 @@ public class Beam implements DetectionInt {
 		if (jsonPowerRatioError != null) {
 			newJSONObject.put(POWERRATIOERROR_KEY, jsonPowerRatioError);
 		}
-
-		// associated
-		if ((jsonAssociationInfo != null) && (!jsonAssociationInfo.isEmpty()))
-			newJSONObject.put(ASSOCIATIONINFO_KEY,
-					jsonAssociationInfo.toJSON());
 
 		return (newJSONObject);
 	}
@@ -553,74 +224,16 @@ public class Beam implements DetectionInt {
 	 */
 	public ArrayList<String> getErrors() {
 
-		String jsonType = getType();
-		String jsonID = getID();
-		Site jsonSite = getSite();
-		Source jsonSource = getSource();
-		Date jsonStartTime = getStartTime();
-		Date jsonEndTime = getEndTime();
 		Double jsonBackAzimuth = getBackAzimuth();
 		Double jsonSlowness = getSlowness();
 		Double jsonPowerRatio = getPowerRatio();
 		Double jsonBackAzimuthError = getBackAzimuthError();
 		Double jsonSlownessError = getSlownessError();
 		Double jsonPowerRatioError = getPowerRatioError();
-		Associated jsonAssociationInfo = getAssociationInfo();
 
 		ArrayList<String> errorList = new ArrayList<String>();
 
 		// Required Keys
-		// type
-		if (jsonType == null) {
-			// type not found
-			errorList.add("No Type in Beam Class.");
-		} else if (jsonType.isEmpty()) {
-			// type empty
-			errorList.add("Empty Type in Beam Class.");
-		} else if (!jsonType.equals("Beam")) {
-			// wrong type
-			errorList.add("Non-Beam type in Beam Class.");
-		}
-
-		// id
-		if (jsonID == null) {
-			// id not found
-			errorList.add("No ID in Beam Class.");
-		} else if (jsonID.isEmpty()) {
-			// id empty
-			errorList.add("Empty ID in Beam Class.");
-		}
-
-		// site
-		if (jsonSite == null) {
-			// site not found
-			errorList.add("No Site in Beam Class.");
-		} else if (!jsonSite.isValid()) {
-			// site invalid
-			errorList.add("Invalid Site in Beam Class.");
-		}
-
-		// source
-		if (jsonSource == null) {
-			// source not found
-			errorList.add("No Source in Beam Class.");
-		} else if (!jsonSource.isValid()) {
-			// source invalid
-			errorList.add("Invalid Source in Beam Class.");
-		}
-
-		// startTime
-		if (jsonStartTime == null) {
-			// time not found
-			errorList.add("No Start Time in Beam Class.");
-		}
-
-		// endTime
-		if (jsonEndTime == null) {
-			// time not found
-			errorList.add("No End Time in Beam Class.");
-		}
-
 		// backAzimuth
 		if (jsonBackAzimuth == null) {
 			// backazimuth not found
@@ -639,16 +252,15 @@ public class Beam implements DetectionInt {
 			errorList.add("Invalid Slowness in Beam Class.");
 		}
 
+		// Optional Keys
 		// powerRatio
-		if (jsonPowerRatio == null) {
-			// powerRatio not found
-			errorList.add("No PowerRatio in Beam Class.");
-		} else if (jsonPowerRatio < 0) {
-			// invalid powerRatio
-			errorList.add("Invalid PowerRatio in Beam Class.");
+		if (jsonPowerRatio != null) {
+			if (jsonPowerRatio < 0) {
+				// invalid powerRatio
+				errorList.add("Invalid PowerRatio in Beam Class.");
+			}
 		}
 
-		// Optional Keys
 		// backAzimuthError
 		if (jsonBackAzimuthError != null) {
 			if (jsonBackAzimuthError < 0) {
@@ -679,58 +291,8 @@ public class Beam implements DetectionInt {
 			}
 		}
 
-		// associated
-		if (jsonAssociationInfo != null) {
-			if (!jsonAssociationInfo.isValid()) {
-				// associationinfo invalid
-				errorList.add("Invalid AssociationInfo in Beam Class.");
-			}
-		}
-
 		// success
 		return (errorList);
-	}
-
-	/**
-	 * @return the type
-	 */
-	public String getType() {
-		return type;
-	}
-
-	/**
-	 * @return the id
-	 */
-	public String getID() {
-		return id;
-	}
-
-	/**
-	 * @return the site
-	 */
-	public Site getSite() {
-		return site;
-	}
-
-	/**
-	 * @return the source
-	 */
-	public Source getSource() {
-		return source;
-	}
-
-	/**
-	 * @return the startTime
-	 */
-	public Date getStartTime() {
-		return startTime;
-	}
-
-	/**
-	 * @return the endTime
-	 */
-	public Date getEndTime() {
-		return endTime;
 	}
 
 	/**
@@ -773,12 +335,5 @@ public class Beam implements DetectionInt {
 	 */
 	public Double getPowerRatioError() {
 		return powerRatioError;
-	}
-
-	/**
-	 * @return the associationInfo
-	 */
-	public Associated getAssociationInfo() {
-		return associationInfo;
 	}
 }

--- a/java/src/gov/usgs/detectionformats/Beam.java
+++ b/java/src/gov/usgs/detectionformats/Beam.java
@@ -3,7 +3,6 @@ package gov.usgs.detectionformats;
 import org.json.simple.JSONObject;
 
 import java.util.ArrayList;
-import java.util.Date;
 
 /**
  * a conversion class used to create, parse, and validate beam detection data

--- a/java/src/gov/usgs/detectionformats/BeamTest.java
+++ b/java/src/gov/usgs/detectionformats/BeamTest.java
@@ -17,27 +17,13 @@ public class BeamTest {
 			+ "{\"Distance\":0.442559,\"Azimuth\":0.418479,\"Phase\":\"P\","
 			+ "\"Sigma\":0.086333,\"Residual\":-0.025393},\"SlownessError\":0.4"
 			+ "\"PowerRatio\":12.18,\"PowerRatioError\":0.557}";
-	public static String ID = "12GFH48776857";
-	public static String STATION = "BMN";
-	public static String CHANNEL = "HHZ";
-	public static String NETWORK = "LB";
-	public static String LOCATION = "01";
-	public static String SITEID = "BMN.HHZ.LB.01";
-	public static String AGENCYID = "US";
-	public static String AUTHOR = "TestAuthor";
-	public static Date STARTTIME = Utility.getDate("2015-12-28T21:32:24.017Z");
-	public static Date ENDTIME = Utility.getDate("2015-12-28T21:32:30.017Z");
+
 	public static double BACKAZIMUTH = 2.65;
 	public static double BACKAZIMUTHERROR = 3.8;
 	public static double SLOWNESS = 1.44;
 	public static double SLOWNESSERROR = 0.4;
 	public static double POWERRATIO = 12.18;
 	public static double POWERRATIOERROR = 0.557;
-	public static String ASSOCPHASE = "P";
-	public static double ASSOCDISTANCE = 0.442559;
-	public static double ASSOCAZIMUTH = 0.418479;
-	public static double ASSOCRESIDUAL = -0.025393;
-	public static double ASSOCSIGMA = 0.086333;
 
 	/**
 	 * Able to write a JSON string
@@ -45,11 +31,8 @@ public class BeamTest {
 	@Test
 	public void writesJSON() {
 
-		Beam beamObject = new Beam(ID, SITEID, STATION, CHANNEL, NETWORK,
-				LOCATION, AGENCYID, AUTHOR, STARTTIME, ENDTIME, BACKAZIMUTH,
-				BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
-				POWERRATIOERROR, ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH,
-				ASSOCRESIDUAL, ASSOCSIGMA);
+		Beam beamObject = new Beam(BACKAZIMUTH, BACKAZIMUTHERROR, SLOWNESS,
+				SLOWNESSERROR, POWERRATIO, POWERRATIOERROR);
 
 		// write out to a string
 		String jsonString = Utility.toJSONString(beamObject.toJSON());
@@ -81,53 +64,13 @@ public class BeamTest {
 	}
 
 	/**
-	 * Constructors fills in members correctly
-	 */
-	@Test
-	public void altConstructors() {
-
-		// use constructor
-		Beam beamObject = new Beam(ID, SITEID, STATION, CHANNEL, NETWORK,
-				LOCATION, AGENCYID, AUTHOR, STARTTIME, ENDTIME, BACKAZIMUTH,
-				BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
-				POWERRATIOERROR);
-
-		// check data values
-		checkData(beamObject, "Alternate Constructor 1");
-
-		// use constructor
-		Beam altBeamObject = new Beam(ID,
-				new Site(SITEID, STATION, CHANNEL, NETWORK, LOCATION),
-				new Source(AGENCYID, AUTHOR), STARTTIME, ENDTIME, BACKAZIMUTH,
-				BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
-				POWERRATIOERROR);
-
-		// check data values
-		checkData(altBeamObject, "Alternate Constructor 2");
-
-		// use constructor
-		Beam altAltBeamObject = new Beam(ID,
-				new Site(SITEID, STATION, CHANNEL, NETWORK, LOCATION),
-				new Source(AGENCYID, AUTHOR), STARTTIME, ENDTIME, BACKAZIMUTH,
-				BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
-				POWERRATIOERROR, new Associated(ASSOCPHASE, ASSOCDISTANCE,
-						ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA));
-
-		// check data values
-		checkData(altAltBeamObject, "Alternate Constructor 3");
-	}
-
-	/**
 	 * Able to run validation function
 	 */
 	@Test
 	public void validate() {
 
-		Beam beamObject = new Beam(ID, SITEID, STATION, CHANNEL, NETWORK,
-				LOCATION, AGENCYID, AUTHOR, STARTTIME, ENDTIME, BACKAZIMUTH,
-				BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
-				POWERRATIOERROR, ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH,
-				ASSOCRESIDUAL, ASSOCSIGMA);
+		Beam beamObject = new Beam(BACKAZIMUTH, BACKAZIMUTHERROR, SLOWNESS,
+				SLOWNESSERROR, POWERRATIO, POWERRATIOERROR);
 
 		// Successful validation
 		boolean rc = beamObject.isValid();
@@ -136,11 +79,8 @@ public class BeamTest {
 		assertEquals("Successful Validation", true, rc);
 
 		// build bad Beam object
-		Beam badBeamObject = new Beam("", null, "", CHANNEL, NETWORK, LOCATION,
-				AGENCYID, AUTHOR, STARTTIME, ENDTIME, null, BACKAZIMUTHERROR,
-				SLOWNESS, SLOWNESSERROR, POWERRATIO, POWERRATIOERROR,
-				ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL,
-				ASSOCSIGMA);
+		Beam badBeamObject = new Beam(null, BACKAZIMUTHERROR, null,
+				SLOWNESSERROR, POWERRATIO, POWERRATIOERROR);
 
 		rc = badBeamObject.isValid();
 
@@ -150,89 +90,36 @@ public class BeamTest {
 
 	public void checkData(Beam beamObject, String TestName) {
 
-		// check beamObject.ID
-		assertEquals(TestName + " ID Equals", ID, beamObject.getID());
-
-		// check beamObject.site.Station
-		assertEquals(TestName + " Station Equals", STATION,
-				beamObject.getSite().getStation());
-
-		// check beamObject.site.Channel
-		assertEquals(TestName + " Channel Equals", CHANNEL,
-				beamObject.getSite().getChannel());
-
-		// check beamObject.site.Network
-		assertEquals(TestName + " Network Equals", NETWORK,
-				beamObject.getSite().getNetwork());
-
-		// check beamObject.site.Location
-		assertEquals(TestName + " Location Equals", LOCATION,
-				beamObject.getSite().getLocation());
-
-		// check beamObject.site.SiteID
-		assertEquals(TestName + " SiteID Equals", SITEID,
-				beamObject.getSite().getSiteID());
-
-		// check beamObject.Source.AgencyID
-		assertEquals(TestName + " AgencyID Equals", AGENCYID,
-				beamObject.getSource().getAgencyID());
-
-		// check beamObject.Source.Author
-		assertEquals(TestName + " Author Equals", AUTHOR,
-				beamObject.getSource().getAuthor());
-
-		// check beamObject.startTime
-		assertEquals(TestName + " Start Time Equals", STARTTIME,
-				beamObject.getStartTime());
-
-		// check beamObject.endTime
-		assertEquals(TestName + " End Time Equals", ENDTIME,
-				beamObject.getEndTime());
-
 		// check beamObject.BackAzimuth
 		assertEquals(TestName + " BackAzimuth Equals", BACKAZIMUTH,
 				beamObject.getBackAzimuth(), 0);
 
 		// check beamObject.BackAzimuthError
-		assertEquals(TestName + " BackAzimuthError Equals", BACKAZIMUTHERROR,
-				beamObject.getBackAzimuthError(), 0);
+		if (beamObject.getBackAzimuthError() != null) {
+			assertEquals(TestName + " BackAzimuthError Equals",
+					BACKAZIMUTHERROR, beamObject.getBackAzimuthError(), 0);
+		}
 
 		// check beamObject.Slowness
 		assertEquals(TestName + " Slowness Equals", SLOWNESS,
 				beamObject.getSlowness(), 0);
 
 		// check beamObject.SlownessError
-		assertEquals(TestName + " SlownessError Equals", SLOWNESSERROR,
-				beamObject.getSlownessError(), 0);
+		if (beamObject.getSlownessError() != null) {
+			assertEquals(TestName + " SlownessError Equals", SLOWNESSERROR,
+					beamObject.getSlownessError(), 0);
+		}
 
 		// check beamObject.PowerRatio
-		assertEquals(TestName + " Slowness Equals", POWERRATIO,
-				beamObject.getPowerRatio(), 0);
+		if (beamObject.getPowerRatio() != null) {
+			assertEquals(TestName + " PowerRatio Equals", POWERRATIO,
+					beamObject.getPowerRatio(), 0);
+		}
 
 		// check beamObject.PowerRatioError
-		assertEquals(TestName + " SlownessError Equals", POWERRATIOERROR,
-				beamObject.getPowerRatioError(), 0);
-
-		if (!beamObject.getAssociationInfo().isEmpty()) {
-			// check beamObject.Associated.Phase
-			assertEquals(TestName + " Phase Equals", ASSOCPHASE,
-					beamObject.getAssociationInfo().getPhase());
-
-			// check beamObject.Associated.Distance
-			assertEquals(TestName + " Distance Equals", ASSOCDISTANCE,
-					beamObject.getAssociationInfo().getDistance(), 0);
-
-			// check beamObject.Associated.Azimuth
-			assertEquals(TestName + " Azimuth Equals", ASSOCAZIMUTH,
-					beamObject.getAssociationInfo().getAzimuth(), 0);
-
-			// check beamObject.Associated.Residual
-			assertEquals(TestName + " Residual Equals", ASSOCRESIDUAL,
-					beamObject.getAssociationInfo().getResidual(), 0);
-
-			// check beamObject.Associated.Sigma
-			assertEquals(TestName + " Sigma Equals", ASSOCSIGMA,
-					beamObject.getAssociationInfo().getSigma(), 0);
+		if (beamObject.getPowerRatioError() != null) {
+			assertEquals(TestName + " PowerRatioError Equals", POWERRATIOERROR,
+					beamObject.getPowerRatioError(), 0);
 		}
 	}
 }

--- a/java/src/gov/usgs/detectionformats/BeamTest.java
+++ b/java/src/gov/usgs/detectionformats/BeamTest.java
@@ -1,7 +1,6 @@
 package gov.usgs.detectionformats;
 
 import static org.junit.Assert.*;
-import java.util.Date;
 import org.json.simple.parser.ParseException;
 import org.junit.Test;
 

--- a/java/src/gov/usgs/detectionformats/Correlation.java
+++ b/java/src/gov/usgs/detectionformats/Correlation.java
@@ -139,8 +139,6 @@ public class Correlation implements DetectionInt {
 	 * 
 	 * @param newID
 	 *            - A String containing the id to use
-	 * @param newSiteID
-	 *            - A String containing the siteid to use
 	 * @param newStation
 	 *            - A String containing the station to use
 	 * @param newChannel
@@ -189,7 +187,7 @@ public class Correlation implements DetectionInt {
 	 * @param newThresholdType
 	 *            - A String containing the threshold type to use, null to omit
 	 */
-	public Correlation(String newID, String newSiteID, String newStation,
+	public Correlation(String newID, String newStation,
 			String newChannel, String newNetwork, String newLocation,
 			String newAgencyID, String newAuthor, String newPhase, Date newTime,
 			Double newCorrelation, Double newLatitude, Double newLongitude,
@@ -200,7 +198,7 @@ public class Correlation implements DetectionInt {
 			String newThresholdType) {
 
 		this(newID,
-				new Site(newSiteID, newStation, newChannel, newNetwork,
+				new Site(newStation, newChannel, newNetwork,
 						newLocation),
 				new Source(newAgencyID, newAuthor), newPhase, newTime,
 				newCorrelation,
@@ -219,8 +217,6 @@ public class Correlation implements DetectionInt {
 	 * 
 	 * @param newID
 	 *            - A String containing the id to use
-	 * @param newSiteID
-	 *            - A String containing the siteid to use
 	 * @param newStation
 	 *            - A String containing the station to use
 	 * @param newChannel
@@ -284,7 +280,7 @@ public class Correlation implements DetectionInt {
 	 *            - A Double containing the associated sigma to use, null to
 	 *            omit
 	 */
-	public Correlation(String newID, String newSiteID, String newStation,
+	public Correlation(String newID, String newStation,
 			String newChannel, String newNetwork, String newLocation,
 			String newAgencyID, String newAuthor, String newPhase, Date newTime,
 			Double newCorrelation, Double newLatitude, Double newLongitude,
@@ -297,7 +293,7 @@ public class Correlation implements DetectionInt {
 			Double newAssociatedResidual, Double newAssociatedSigma) {
 
 		this(newID,
-				new Site(newSiteID, newStation, newChannel, newNetwork,
+				new Site(newStation, newChannel, newNetwork,
 						newLocation),
 				new Source(newAgencyID, newAuthor), newPhase, newTime,
 				newCorrelation,

--- a/java/src/gov/usgs/detectionformats/CorrelationTest.java
+++ b/java/src/gov/usgs/detectionformats/CorrelationTest.java
@@ -11,8 +11,7 @@ public class CorrelationTest {
 
 	public static String CORRELATION_STRING = "{\"ZScore\":33.67,"
 			+ "\"Site\":{\"Station\":\"BMN\",\"Channel\":\"HHZ\","
-			+ "\"Network\":\"LB\",\"Location\":\"01\","
-			+ "\"SiteID\":\"BMN.HHZ.LB.01\"},\"Magnitude\":2.14,"
+			+ "\"Network\":\"LB\",\"Location\":\"01\"},\"Magnitude\":2.14,"
 			+ "\"Type\":\"Correlation\",\"Correlation\":2.65,"
 			+ "\"EventType\":\"earthquake\","
 			+ "\"AssociationInfo\":{\"Distance\":0.442559,\"Azimuth\":0.418479,"
@@ -32,7 +31,6 @@ public class CorrelationTest {
 	public static String CHANNEL = "HHZ";
 	public static String NETWORK = "LB";
 	public static String LOCATION = "01";
-	public static String SITEID = "BMN.HHZ.LB.01";
 	public static String AGENCYID = "US";
 	public static String AUTHOR = "TestAuthor";
 	public static Date TIME = Utility.getDate("2015-12-28T21:32:24.017Z");
@@ -64,13 +62,12 @@ public class CorrelationTest {
 	@Test
 	public void writesJSON() {
 
-		Correlation correlationObject = new Correlation(ID, SITEID, STATION,
-				CHANNEL, NETWORK, LOCATION, AGENCYID, AUTHOR, PHASE, TIME,
-				CORRELATION, LATITUDE, LONGITUDE, ORIGINTIME, DEPTH,
-				LATITUDEERROR, LONGITUDEERROR, TIMEERROR, DEPTHERROR, EVENTTYPE,
-				MAGNITUDE, SNR, ZSCORE, DETECTIONTHRESHOLD, THRESHOLDTYPE,
-				ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL,
-				ASSOCSIGMA);
+		Correlation correlationObject = new Correlation(ID, STATION, CHANNEL,
+				NETWORK, LOCATION, AGENCYID, AUTHOR, PHASE, TIME, CORRELATION,
+				LATITUDE, LONGITUDE, ORIGINTIME, DEPTH, LATITUDEERROR,
+				LONGITUDEERROR, TIMEERROR, DEPTHERROR, EVENTTYPE, MAGNITUDE,
+				SNR, ZSCORE, DETECTIONTHRESHOLD, THRESHOLDTYPE, ASSOCPHASE,
+				ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
 
 		// write out to a string
 		String jsonString = Utility.toJSONString(correlationObject.toJSON());
@@ -109,23 +106,22 @@ public class CorrelationTest {
 	public void altConstructors() {
 
 		// use constructor
-		Correlation correlationObject = new Correlation(ID, SITEID, STATION,
-				CHANNEL, NETWORK, LOCATION, AGENCYID, AUTHOR, PHASE, TIME,
-				CORRELATION, LATITUDE, LONGITUDE, ORIGINTIME, DEPTH,
-				LATITUDEERROR, LONGITUDEERROR, TIMEERROR, DEPTHERROR, EVENTTYPE,
-				MAGNITUDE, SNR, ZSCORE, DETECTIONTHRESHOLD, THRESHOLDTYPE,
-				ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL,
-				ASSOCSIGMA);
+		Correlation correlationObject = new Correlation(ID, STATION, CHANNEL,
+				NETWORK, LOCATION, AGENCYID, AUTHOR, PHASE, TIME, CORRELATION,
+				LATITUDE, LONGITUDE, ORIGINTIME, DEPTH, LATITUDEERROR,
+				LONGITUDEERROR, TIMEERROR, DEPTHERROR, EVENTTYPE, MAGNITUDE,
+				SNR, ZSCORE, DETECTIONTHRESHOLD, THRESHOLDTYPE, ASSOCPHASE,
+				ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
 
 		// check data values
 		checkData(correlationObject, "Alternate Constructor 1");
 
 		// use constructor
 		Correlation altCorrelationObject = new Correlation(ID,
-				new Site(SITEID, STATION, CHANNEL, NETWORK, LOCATION),
+				new Site(STATION, CHANNEL, NETWORK, LOCATION),
 				new Source(AGENCYID, AUTHOR), PHASE, TIME, CORRELATION,
-				new Hypocenter(LATITUDE, LONGITUDE, ORIGINTIME, DEPTH, LATITUDEERROR,
-						LONGITUDEERROR, TIMEERROR, DEPTHERROR),
+				new Hypocenter(LATITUDE, LONGITUDE, ORIGINTIME, DEPTH,
+						LATITUDEERROR, LONGITUDEERROR, TIMEERROR, DEPTHERROR),
 				EVENTTYPE, MAGNITUDE, SNR, ZSCORE, DETECTIONTHRESHOLD,
 				THRESHOLDTYPE);
 
@@ -134,10 +130,10 @@ public class CorrelationTest {
 
 		// use constructor
 		Correlation altAltCorrelationObject = new Correlation(ID,
-				new Site(SITEID, STATION, CHANNEL, NETWORK, LOCATION),
+				new Site(STATION, CHANNEL, NETWORK, LOCATION),
 				new Source(AGENCYID, AUTHOR), PHASE, TIME, CORRELATION,
-				new Hypocenter(LATITUDE, LONGITUDE, ORIGINTIME, DEPTH, LATITUDEERROR,
-						LONGITUDEERROR, TIMEERROR, DEPTHERROR),
+				new Hypocenter(LATITUDE, LONGITUDE, ORIGINTIME, DEPTH,
+						LATITUDEERROR, LONGITUDEERROR, TIMEERROR, DEPTHERROR),
 				EVENTTYPE, MAGNITUDE, SNR, ZSCORE, DETECTIONTHRESHOLD,
 				THRESHOLDTYPE, new Associated(ASSOCPHASE, ASSOCDISTANCE,
 						ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA));
@@ -152,13 +148,12 @@ public class CorrelationTest {
 	@Test
 	public void validate() {
 
-		Correlation correlationObject = new Correlation(ID, SITEID, STATION,
-				CHANNEL, NETWORK, LOCATION, AGENCYID, AUTHOR, PHASE, TIME,
-				CORRELATION, LATITUDE, LONGITUDE, ORIGINTIME, DEPTH,
-				LATITUDEERROR, LONGITUDEERROR, TIMEERROR, DEPTHERROR, EVENTTYPE,
-				MAGNITUDE, SNR, ZSCORE, DETECTIONTHRESHOLD, THRESHOLDTYPE,
-				ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL,
-				ASSOCSIGMA);
+		Correlation correlationObject = new Correlation(ID, STATION, CHANNEL,
+				NETWORK, LOCATION, AGENCYID, AUTHOR, PHASE, TIME, CORRELATION,
+				LATITUDE, LONGITUDE, ORIGINTIME, DEPTH, LATITUDEERROR,
+				LONGITUDEERROR, TIMEERROR, DEPTHERROR, EVENTTYPE, MAGNITUDE,
+				SNR, ZSCORE, DETECTIONTHRESHOLD, THRESHOLDTYPE, ASSOCPHASE,
+				ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
 
 		// Successful validation
 		boolean rc = correlationObject.isValid();
@@ -167,13 +162,12 @@ public class CorrelationTest {
 		assertEquals("Successful Validation", true, rc);
 
 		// build bad Correlation object
-		Correlation badCorrelationObject = new Correlation("", null, "",
-				CHANNEL, NETWORK, LOCATION, AGENCYID, AUTHOR, PHASE, TIME,
-				CORRELATION, LATITUDE, LONGITUDE, ORIGINTIME, DEPTH,
-				LATITUDEERROR, LONGITUDEERROR, TIMEERROR, DEPTHERROR, EVENTTYPE,
-				MAGNITUDE, SNR, ZSCORE, DETECTIONTHRESHOLD, THRESHOLDTYPE,
-				ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL,
-				ASSOCSIGMA);
+		Correlation badCorrelationObject = new Correlation("", "", CHANNEL,
+				null, LOCATION, AGENCYID, AUTHOR, PHASE, TIME, CORRELATION,
+				LATITUDE, LONGITUDE, ORIGINTIME, DEPTH, LATITUDEERROR,
+				LONGITUDEERROR, TIMEERROR, DEPTHERROR, EVENTTYPE, MAGNITUDE,
+				SNR, ZSCORE, DETECTIONTHRESHOLD, THRESHOLDTYPE, ASSOCPHASE,
+				ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
 
 		rc = badCorrelationObject.isValid();
 
@@ -201,10 +195,6 @@ public class CorrelationTest {
 		// check correlationObject.site.Location
 		assertEquals(TestName + " Location Equals", LOCATION,
 				correlationObject.getSite().getLocation());
-
-		// check correlationObject.site.SiteID
-		assertEquals(TestName + " SiteID Equals", SITEID,
-				correlationObject.getSite().getSiteID());
 
 		// check correlationObject.Source.AgencyID
 		assertEquals(TestName + " AgencyID Equals", AGENCYID,
@@ -283,7 +273,8 @@ public class CorrelationTest {
 		assertEquals(TestName + " ThresholdType Equals", THRESHOLDTYPE,
 				correlationObject.getThresholdType());
 
-		if (!correlationObject.getAssociationInfo().isEmpty()) {
+		if ((correlationObject.getAssociationInfo() != null)
+				&& (!correlationObject.getAssociationInfo().isEmpty())) {
 			// check correlationObject.Associated.Phase
 			assertEquals(TestName + " Phase Equals", ASSOCPHASE,
 					correlationObject.getAssociationInfo().getPhase());

--- a/java/src/gov/usgs/detectionformats/Detection.java
+++ b/java/src/gov/usgs/detectionformats/Detection.java
@@ -85,11 +85,6 @@ public class Detection implements DetectionInt {
 	private final ArrayList<Pick> pickData;
 
 	/**
-	 * An optional vector of Beam objects used to generate this origin
-	 */
-	private final ArrayList<Beam> beamData;
-
-	/**
 	 * An optional vector of Detection objects used to generate this origin
 	 */
 	private final ArrayList<Correlation> correlationData;
@@ -111,7 +106,6 @@ public class Detection implements DetectionInt {
 		rms = null;
 		gap = null;
 		pickData = null;
-		beamData = null;
 		correlationData = null;
 	}
 
@@ -159,9 +153,6 @@ public class Detection implements DetectionInt {
 	 * @param newPickData
 	 *            - A ArrayList&lt;Pick&gt; newPickData containing the data that
 	 *            went into this origin, null to omit
-	 * @param newBeamData
-	 *            - A ArrayList&lt;Beam&gt; newBeamData containing the data that
-	 *            went into this origin, null to omit
 	 * @param newCorrelationData
 	 *            - A ArrayList&lt;Detection&gt; newCorrelationData containing
 	 *            the data that went into this origin, null to omit
@@ -172,7 +163,6 @@ public class Detection implements DetectionInt {
 			Double newTimeError, Double newDepthError, String newDetectionType,
 			String newEventType, Double newBayes, Double newMinimumDistance,
 			Double newRMS, Double newGap, ArrayList<Pick> newPickData,
-			ArrayList<Beam> newBeamData,
 			ArrayList<Correlation> newCorrelationData) {
 
 		this(newID, new Source(newAgencyID, newAuthor),
@@ -180,7 +170,7 @@ public class Detection implements DetectionInt {
 						newLatitudeError, newLongitudeError, newTimeError,
 						newDepthError),
 				newDetectionType, newEventType, newBayes, newMinimumDistance,
-				newRMS, newGap, newPickData, newBeamData, newCorrelationData);
+				newRMS, newGap, newPickData, newCorrelationData);
 	}
 
 	/**
@@ -209,19 +199,16 @@ public class Detection implements DetectionInt {
 	 * @param newGap
 	 *            - A Double containing the gap to use, null to omit
 	 * @param newPickData
-	 *            - A Vector&lt;Pick&gt; newPickData containing the data that
-	 *            went into this origin, null to omit
-	 * @param newBeamData
-	 *            - A Vector&lt;Beam&gt; newBeamData containing the data that
+	 *            - A ArrayList&lt;Pick&gt; newPickData containing the data that
 	 *            went into this origin, null to omit
 	 * @param newCorrelationData
-	 *            - A Vector&lt;Detection&gt; newCorrelationData containing the
+	 *            - A ArrayList&lt;Detection&gt; newCorrelationData containing the
 	 *            data that went into this origin, null to omit
 	 */
 	public Detection(String newID, Source newSource, Hypocenter newHypocenter,
 			String newDetectionType, String newEventType, Double newBayes,
 			Double newMinimumDistance, Double newRMS, Double newGap,
-			ArrayList<Pick> newPickData, ArrayList<Beam> newBeamData,
+			ArrayList<Pick> newPickData,
 			ArrayList<Correlation> newCorrelationData) {
 
 		type = "Detection";
@@ -236,7 +223,6 @@ public class Detection implements DetectionInt {
 		gap = newGap;
 
 		pickData = newPickData;
-		beamData = newBeamData;
 		correlationData = newCorrelationData;
 	}
 
@@ -325,7 +311,6 @@ public class Detection implements DetectionInt {
 		if (newJSONObject.containsKey(DATA_KEY)) {
 
 			pickData = new ArrayList<Pick>();
-			beamData = new ArrayList<Beam>();
 			correlationData = new ArrayList<Correlation>();
 
 			// get the array
@@ -348,10 +333,6 @@ public class Detection implements DetectionInt {
 
 							// add to vector
 							pickData.add(new Pick(dataObject));
-						} else if (TypeString.equals("Beam")) {
-
-							// add to vector
-							beamData.add(new Beam(dataObject));
 						} else if (TypeString.equals("Correlation")) {
 
 							// add to vector
@@ -363,7 +344,6 @@ public class Detection implements DetectionInt {
 			}
 		} else {
 			pickData = null;
-			beamData = null;
 			correlationData = null;
 		}
 
@@ -390,7 +370,6 @@ public class Detection implements DetectionInt {
 		Double jsonRMS = getRMS();
 		Double jsonGap = getGap();
 		ArrayList<Pick> jsonPickData = getPickData();
-		ArrayList<Beam> jsonBeamData = getBeamData();
 		ArrayList<Correlation> jsonCorrelationData = getCorrelationData();
 
 		// Required values
@@ -460,20 +439,6 @@ public class Detection implements DetectionInt {
 			}
 		}
 
-		// Beams
-		if ((jsonBeamData != null) && (!jsonBeamData.isEmpty())) {
-
-			// enumerate through the whole arraylist
-			for (Iterator<Beam> beamIterator = jsonBeamData
-					.iterator(); beamIterator.hasNext();) {
-
-				// convert beam to JSON object
-				JSONObject beamObject = ((Beam) beamIterator.next()).toJSON();
-
-				dataArray.add(beamObject);
-			}
-		}
-
 		// Correlation
 		if ((jsonCorrelationData != null) && (!jsonCorrelationData.isEmpty())) {
 
@@ -529,7 +494,6 @@ public class Detection implements DetectionInt {
 		Double jsonMinimumDistance = getMinimumDistance();
 		Double jsonGap = getGap();
 		ArrayList<Pick> jsonPickData = getPickData();
-		ArrayList<Beam> jsonBeamData = getBeamData();
 		ArrayList<Correlation> jsonCorrelationData = getCorrelationData();
 
 		ArrayList<String> errorList = new ArrayList<String>();
@@ -661,24 +625,6 @@ public class Detection implements DetectionInt {
 			}
 		}
 
-		// Beams
-		if ((jsonBeamData != null) && (!jsonBeamData.isEmpty())) {
-
-			// enumerate through the whole arraylist
-			for (Iterator<Beam> beamIterator = jsonBeamData
-					.iterator(); beamIterator.hasNext();) {
-
-				// convert beam to JSON object
-				Beam jsonBeam = ((Beam) beamIterator.next());
-
-				if (!jsonBeam.isValid()) {
-					errorList
-							.add("Invalid Beam in BeamData in Detection Class");
-					break;
-				}
-			}
-		}
-
 		// Correlation
 		if ((jsonCorrelationData != null) && (!jsonCorrelationData.isEmpty())) {
 
@@ -776,13 +722,6 @@ public class Detection implements DetectionInt {
 	 */
 	public ArrayList<Pick> getPickData() {
 		return pickData;
-	}
-
-	/**
-	 * @return the beamData
-	 */
-	public ArrayList<Beam> getBeamData() {
-		return beamData;
 	}
 
 	/**

--- a/java/src/gov/usgs/detectionformats/DetectionTest.java
+++ b/java/src/gov/usgs/detectionformats/DetectionTest.java
@@ -15,22 +15,13 @@ public class DetectionTest {
 			+ "\"questionable\",\"Amplitude\":{\"Period\":2.65,\"Amplitude\":"
 			+ "21.5,\"SNR\":3.8},\"Time\":\"2015-12-28T21:32:24.017Z\",\"Site\":"
 			+ "{\"Station\":\"BMN\",\"Channel\":\"HHZ\",\"Network\":\"LB\","
-			+ "\"Location\":\"01\",\"SiteID\":\"BMN.HHZ.LB.01\"},\"Type\":"
+			+ "\"Location\":\"01\"},\"Type\":"
 			+ "\"Pick\",\"ID\":\"12GFH48776857\",\"Polarity\":\"up\",\"Phase\":"
 			+ "\"P\",\"Picker\":\"manual\",\"AssociationInfo\":{\"Distance\":"
 			+ "0.442559,\"Azimuth\":0.418479,\"Phase\":\"P\",\"Sigma\":0.086333,"
-			+ "\"Residual\":-0.025393}},{\"Source\":{\"Author\":\"TestAuthor\","
-			+ "\"AgencyID\":\"US\"},\"Site\":{\"Station\":\"BMN\",\"Channel\":"
-			+ "\"HHZ\",\"Network\":\"LB\",\"Location\":\"01\",\"SiteID\":"
-			+ "\"BMN.HHZ.LB.01\"},\"Type\":\"Beam\",\"BackAzimuth\":2.65,\"ID\":"
-			+ "\"12GFH48776857\",\"EndTime\":\"2015-12-28T21:32:30.017Z\","
-			+ "\"StartTime\":\"2015-12-28T21:32:24.017Z\",\"BackAzimuthError\":"
-			+ "3.8,\"Slowness\":1.44,\"PowerRatio\":12.18,\"PowerRatioError\":0.557,"
-			+ "\"AssociationInfo\":{\"Distance\":0.442559,"
-			+ "\"Azimuth\":0.418479,\"Phase\":\"P\",\"Sigma\":0.086333,"
-			+ "\"Residual\":-0.025393},\"SlownessError\":0.4},{\"ZScore\":33.67,"
+			+ "\"Residual\":-0.025393}},{\"ZScore\":33.67,"
 			+ "\"Site\":{\"Station\":\"BMN\",\"Channel\":\"HHZ\",\"Network\":"
-			+ "\"LB\",\"Location\":\"01\",\"SiteID\":\"BMN.HHZ.LB.01\"},"
+			+ "\"LB\",\"Location\":\"01\"},"
 			+ "\"Magnitude\":2.14,\"Type\":\"Correlation\",\"Correlation\":2.65,"
 			+ "\"EventType\":\"earthquake\",\"AssociationInfo\":{\"Distance\":"
 			+ "0.442559,\"Azimuth\":0.418479,\"Phase\":\"P\",\"Sigma\":0.086333,"
@@ -66,7 +57,7 @@ public class DetectionTest {
 	public static double RMS = 3.8;
 	public static double GAP = 33.67;
 	public static String PICKDATA = "{\"Type\":\"Pick\",\"ID\":\"12GFH48776857\""
-			+ ",\"Site\":{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\","
+			+ ",\"Site\":{\"Station\":\"BMN\","
 			+ "\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},"
 			+ "\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},"
 			+ "\"Time\":\"2015-12-28T21:32:24.017Z\",\"Phase\":\"P\","
@@ -75,20 +66,9 @@ public class DetectionTest {
 			+ "\"Amplitude\":{\"Amplitude\":21.5,\"Period\":2.65,\"SNR\":3.8},"
 			+ "\"AssociationInfo\":{\"Phase\":\"P\",\"Distance\":0.442559,"
 			+ "\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}";
-	public static String BEAMDATA = "{\"Type\":\"Beam\",\"ID\":\"12GFH48776857\""
-			+ ",\"Site\":{\"SiteID\":\"BMN.HHZ.LB.01\",\"Station\":\"BMN\","
-			+ "\"Network\":\"LB\",\"Channel\":\"HHZ\",\"Location\":\"01\"},"
-			+ "\"Source\":{\"AgencyID\":\"US\",\"Author\":\"TestAuthor\"},"
-			+ "\"StartTime\":\"2015-12-28T21:32:24.017Z\","
-			+ "\"EndTime\":\"2015-12-28T21:32:30.017Z\",\"BackAzimuth\":2.65,"
-			+ "\"Slowness\":1.44,\"BackAzimuthError\":3.8,\"SlownessError\":0.4,"
-			+ "\"PowerRatio\":12.18,\"PowerRatioError\":0.557,\"AssociationInfo\":"
-			+ "{\"Phase\":\"P\",\"Distance\":0.442559,"
-			+ "\"Azimuth\":0.418479,\"Residual\":-0.025393,\"Sigma\":0.086333}}";
 	public static String CORRELATIONDATA = "{\"ZScore\":33.67,"
 			+ "\"Site\":{\"Station\":\"BMN\",\"Channel\":\"HHZ\","
-			+ "\"Network\":\"LB\",\"Location\":\"01\","
-			+ "\"SiteID\":\"BMN.HHZ.LB.01\"},\"Magnitude\":2.14,"
+			+ "\"Network\":\"LB\",\"Location\":\"01\"},\"Magnitude\":2.14,"
 			+ "\"Type\":\"Correlation\",\"Correlation\":2.65,"
 			+ "\"EventType\":\"earthquake\","
 			+ "\"AssociationInfo\":{\"Distance\":0.442559,\"Azimuth\":0.418479,"
@@ -112,7 +92,7 @@ public class DetectionTest {
 		Detection originObject = new Detection(ID, AGENCYID, AUTHOR, LATITUDE,
 				LONGITUDE, TIME, DEPTH, LATITUDEERROR, LONGITUDEERROR,
 				TIMEERROR, DEPTHERROR, DETECTIONTYPE, EVENTTYPE, BAYES,
-				MINIMUMDISTANCE, RMS, GAP, buildPickData(), buildBeamData(),
+				MINIMUMDISTANCE, RMS, GAP, buildPickData(),
 				buildCorrelationData());
 
 		// write out to a string
@@ -154,7 +134,7 @@ public class DetectionTest {
 				new Hypocenter(LATITUDE, LONGITUDE, TIME, DEPTH, LATITUDEERROR,
 						LONGITUDEERROR, TIMEERROR, DEPTHERROR),
 				DETECTIONTYPE, EVENTTYPE, BAYES, MINIMUMDISTANCE, RMS, GAP,
-				buildPickData(), buildBeamData(), buildCorrelationData());
+				buildPickData(), buildCorrelationData());
 
 		// check data values
 		checkData(originObject, "Alternate Constructor 1");
@@ -169,7 +149,7 @@ public class DetectionTest {
 		Detection originObject = new Detection(ID, AGENCYID, AUTHOR, LATITUDE,
 				LONGITUDE, TIME, DEPTH, LATITUDEERROR, LONGITUDEERROR,
 				TIMEERROR, DEPTHERROR, DETECTIONTYPE, EVENTTYPE, BAYES,
-				MINIMUMDISTANCE, RMS, GAP, buildPickData(), buildBeamData(),
+				MINIMUMDISTANCE, RMS, GAP, buildPickData(),
 				buildCorrelationData());
 
 		// Successful validation
@@ -182,8 +162,7 @@ public class DetectionTest {
 		Detection badOriginObject = new Detection("", AGENCYID, null, LATITUDE,
 				null, TIME, DEPTH, LATITUDEERROR, LONGITUDEERROR, TIMEERROR,
 				DEPTHERROR, DETECTIONTYPE, EVENTTYPE, BAYES, MINIMUMDISTANCE,
-				RMS, GAP, buildPickData(), buildBeamData(),
-				buildCorrelationData());
+				RMS, GAP, buildPickData(), buildCorrelationData());
 
 		rc = badOriginObject.isValid();
 
@@ -264,18 +243,6 @@ public class DetectionTest {
 			e.printStackTrace();
 		}
 		return (newPickData);
-	}
-
-	public ArrayList<Beam> buildBeamData() {
-		ArrayList<Beam> newBeamData = new ArrayList<Beam>();
-
-		// Beam ?need one more?
-		try {
-			newBeamData.add(new Beam(Utility.fromJSONString(BEAMDATA)));
-		} catch (ParseException e) {
-			e.printStackTrace();
-		}
-		return (newBeamData);
 	}
 
 	public ArrayList<Correlation> buildCorrelationData() {

--- a/java/src/gov/usgs/detectionformats/Hypocenter.java
+++ b/java/src/gov/usgs/detectionformats/Hypocenter.java
@@ -275,10 +275,6 @@ public class Hypocenter implements DetectionInt {
 		Double jsonLongitude = getLongitude();
 		Date jsonTime = getTime();
 		Double jsonDepth = getDepth();
-		Double jsonLatitudeError = getLatitudeError();
-		Double jsonLongitudeError = getLongitudeError();
-		Double jsonTimeError = getTimeError();
-		Double jsonDepthError = getDepthError();
 
 		ArrayList<String> errorList = new ArrayList<String>();
 

--- a/java/src/gov/usgs/detectionformats/Pick.java
+++ b/java/src/gov/usgs/detectionformats/Pick.java
@@ -6,7 +6,6 @@ import org.json.simple.JSONObject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.Iterator;
 
 /**
  * a conversion class used to create, parse, and validate pick detection data

--- a/java/src/gov/usgs/detectionformats/Pick.java
+++ b/java/src/gov/usgs/detectionformats/Pick.java
@@ -29,6 +29,7 @@ public class Pick implements DetectionInt {
 	public static final String PICKER_KEY = "Picker";
 	public static final String FILTER_KEY = "Filter";
 	public static final String AMPLITUDE_KEY = "Amplitude";
+	public static final String BEAM_KEY = "Beam";
 	public static final String ASSOCIATIONINFO_KEY = "AssociationInfo";
 
 	/**
@@ -87,6 +88,11 @@ public class Pick implements DetectionInt {
 	private final Amplitude amplitude;
 
 	/**
+	 * Optional beam information.
+	 */
+	private final Beam beam;
+
+	/**
 	 * Optional associated information.
 	 */
 	private final Associated associationInfo;
@@ -107,6 +113,7 @@ public class Pick implements DetectionInt {
 		picker = null;
 		filterList = null;
 		amplitude = null;
+		beam = null;
 		associationInfo = null;
 	}
 
@@ -116,8 +123,6 @@ public class Pick implements DetectionInt {
 	 * 
 	 * @param newID
 	 *            - A String containing the id to use
-	 * @param newSiteID
-	 *            - A String containing the siteid to use
 	 * @param newStation
 	 *            - A String containing the station to use
 	 * @param newChannel
@@ -151,6 +156,20 @@ public class Pick implements DetectionInt {
 	 *            - A Double containing the period to use, null to omit
 	 * @param newSNR
 	 *            - A Double containing the snr to use, null to omit
+	 * @param newBackAzimuth
+	 *            - A Double containing the back azimuth to use
+	 * @param newBackAzimutherror
+	 *            - A Double containing the back azimuth error to use, null to
+	 *            omit
+	 * @param newSlowness
+	 *            - A Double containing the slowness to use
+	 * @param newSlownessError
+	 *            - A Double containing the slowness error to use, null to omit
+	 * @param newPowerRatio
+	 *            - A Double containing the power ratio to use, null to omit
+	 * @param newPowerRatioError
+	 *            - A Double containing the power ratio error to use, null to
+	 *            omit
 	 * @param newAssociatedPhase
 	 *            - A std:Stringcontaining the associated phase to use, null to
 	 *            omit
@@ -167,23 +186,26 @@ public class Pick implements DetectionInt {
 	 *            - A Double containing the associated sigma to use, null to
 	 *            omit
 	 */
-	public Pick(String newID, String newSiteID, String newStation,
-			String newChannel, String newNetwork, String newLocation,
-			Date newTime, String newAgencyID, String newAuthor, String newPhase,
+	public Pick(String newID, String newStation, String newChannel,
+			String newNetwork, String newLocation, Date newTime,
+			String newAgencyID, String newAuthor, String newPhase,
 			String newPolarity, String newOnset, String newPicker,
 			Double newHighPass, Double newLowPass, Double newAmplitude,
-			Double newPeriod, Double newSNR, String newAssociatedPhase,
+			Double newPeriod, Double newSNR, Double newBackAzimuth,
+			Double newBackAzimutherror, Double newSlowness,
+			Double newSlownessError, Double newPowerRatio,
+			Double newPowerRatioError, String newAssociatedPhase,
 			Double newAssociatedDistance, Double newAssociatedAzimuth,
 			Double newAssociatedResidual, Double newAssociatedSigma) {
 
-		this(newID,
-				new Site(newSiteID, newStation, newChannel, newNetwork,
-						newLocation),
+		this(newID, new Site(newStation, newChannel, newNetwork, newLocation),
 				newTime, new Source(newAgencyID, newAuthor), newPhase,
 				newPolarity, newOnset, newPicker,
 				new ArrayList<Filter>(
 						Arrays.asList(new Filter(newHighPass, newLowPass))),
 				new Amplitude(newAmplitude, newPeriod, newSNR),
+				new Beam(newBackAzimuth, newBackAzimutherror, newSlowness,
+						newSlownessError, newPowerRatio, newPowerRatioError),
 				new Associated(newAssociatedPhase, newAssociatedDistance,
 						newAssociatedAzimuth, newAssociatedResidual,
 						newAssociatedSigma));
@@ -195,8 +217,6 @@ public class Pick implements DetectionInt {
 	 * 
 	 * @param newID
 	 *            - A String containing the id to use
-	 * @param newSiteID
-	 *            - A String containing the siteid to use
 	 * @param newStation
 	 *            - A String containing the station to use
 	 * @param newChannel
@@ -229,22 +249,39 @@ public class Pick implements DetectionInt {
 	 *            - A Double containing the period to use, null to omit
 	 * @param newSNR
 	 *            - A Double containing the snr to use, null to omit
+	 * @param newBackAzimuth
+	 *            - A Double containing the back azimuth to use
+	 * @param newBackAzimutherror
+	 *            - A Double containing the back azimuth error to use, null to
+	 *            omit
+	 * @param newSlowness
+	 *            - A Double containing the slowness to use
+	 * @param newSlownessError
+	 *            - A Double containing the slowness error to use, null to omit
+	 * @param newPowerRatio
+	 *            - A Double containing the power ratio to use, null to omit
+	 * @param newPowerRatioError
+	 *            - A Double containing the power ratio error to use, null to
+	 *            omit
 	 */
-	public Pick(String newID, String newSiteID, String newStation,
-			String newChannel, String newNetwork, String newLocation,
-			Date newTime, String newAgencyID, String newAuthor, String newPhase,
+	public Pick(String newID, String newStation, String newChannel,
+			String newNetwork, String newLocation, Date newTime,
+			String newAgencyID, String newAuthor, String newPhase,
 			String newPolarity, String newOnset, String newPicker,
 			Double newHighPass, Double newLowPass, Double newAmplitude,
-			Double newPeriod, Double newSNR) {
+			Double newPeriod, Double newSNR, Double newBackAzimuth,
+			Double newBackAzimutherror, Double newSlowness,
+			Double newSlownessError, Double newPowerRatio,
+			Double newPowerRatioError) {
 
-		this(newID,
-				new Site(newSiteID, newStation, newChannel, newNetwork,
-						newLocation),
+		this(newID, new Site(newStation, newChannel, newNetwork, newLocation),
 				newTime, new Source(newAgencyID, newAuthor), newPhase,
 				newPolarity, newOnset, newPicker,
 				new ArrayList<Filter>(
 						Arrays.asList(new Filter(newHighPass, newLowPass))),
-				new Amplitude(newAmplitude, newPeriod, newSNR));
+				new Amplitude(newAmplitude, newPeriod, newSNR),
+				new Beam(newBackAzimuth, newBackAzimutherror, newSlowness,
+						newSlownessError, newPowerRatio, newPowerRatioError));
 	}
 
 	/**
@@ -269,17 +306,22 @@ public class Pick implements DetectionInt {
 	 * @param newPicker
 	 *            - A String containing the picker to use, null to omit
 	 * @param newFilter
-	 *            - A Double containing the filter to use, null to omit
+	 *            - An ArrayList&lt;Filter&gt; objects containing the filters to
+	 *            use, null to omit
 	 * @param newAmplitude
+	 *            - An Amplitude object containing the amplitude to us, null to
+	 *            omit
+	 * @param newBeam
 	 *            - A Double containing the amplitude to us, null to omit
 	 */
 	public Pick(String newID, Site newSite, Date newTime, Source newSource,
 			String newPhase, String newPolarity, String newOnset,
 			String newPicker, ArrayList<Filter> newFilter,
-			Amplitude newAmplitude) {
+			Amplitude newAmplitude, Beam newBeam) {
 
 		this(newID, newSite, newTime, newSource, newPhase, newPolarity,
-				newOnset, newPicker, newFilter, newAmplitude, new Associated());
+				newOnset, newPicker, newFilter, newAmplitude, newBeam,
+				new Associated());
 	}
 
 	/**
@@ -306,6 +348,9 @@ public class Pick implements DetectionInt {
 	 * @param newFilter
 	 *            - A Double containing the filter to use, null to omit
 	 * @param newAmplitude
+	 *            - An Amplitude object containing the amplitude to us, null to
+	 *            omit
+	 * @param newBeam
 	 *            - A Double containing the amplitude to us, null to omit
 	 * @param newAssociated
 	 *            - A Associated containing the associated to use, null to omit
@@ -313,7 +358,7 @@ public class Pick implements DetectionInt {
 	public Pick(String newID, Site newSite, Date newTime, Source newSource,
 			String newPhase, String newPolarity, String newOnset,
 			String newPicker, ArrayList<Filter> newFilter,
-			Amplitude newAmplitude, Associated newAssociated) {
+			Amplitude newAmplitude, Beam newBeam, Associated newAssociated) {
 
 		type = "Pick";
 		id = newID;
@@ -326,6 +371,7 @@ public class Pick implements DetectionInt {
 		picker = newPicker;
 		filterList = newFilter;
 		amplitude = newAmplitude;
+		beam = newBeam;
 		associationInfo = newAssociated;
 	}
 
@@ -435,6 +481,14 @@ public class Pick implements DetectionInt {
 			amplitude = null;
 		}
 
+		// beam
+		if (newJSONObject.containsKey(BEAM_KEY)) {
+			beam = new Beam(
+					(JSONObject) newJSONObject.get(BEAM_KEY));
+		} else {
+			beam = null;
+		}		
+		
 		// associated
 		if (newJSONObject.containsKey(ASSOCIATIONINFO_KEY)) {
 			associationInfo = new Associated(
@@ -467,6 +521,7 @@ public class Pick implements DetectionInt {
 		String jsonPicker = getPicker();
 		ArrayList<Filter> jsonFilterList = getFilterList();
 		Amplitude jsonAmplitude = getAmplitude();
+		Beam jsonBeam = getBeam();
 		Associated jsonAssociationInfo = getAssociationInfo();
 
 		// Required values
@@ -531,6 +586,10 @@ public class Pick implements DetectionInt {
 		if ((jsonAmplitude != null) && (!jsonAmplitude.isEmpty()))
 			newJSONObject.put(AMPLITUDE_KEY, jsonAmplitude.toJSON());
 
+		// beam
+		if (jsonBeam != null) 
+			newJSONObject.put(BEAM_KEY, jsonBeam.toJSON());		
+		
 		// associated
 		if ((jsonAssociationInfo != null) && (!jsonAssociationInfo.isEmpty()))
 			newJSONObject.put(ASSOCIATIONINFO_KEY,
@@ -573,6 +632,7 @@ public class Pick implements DetectionInt {
 		String jsonPicker = getPicker();
 		ArrayList<Filter> jsonFilterList = getFilterList();
 		Amplitude jsonAmplitude = getAmplitude();
+		Beam jsonBeam = getBeam();
 		Associated jsonAssociationInfo = getAssociationInfo();
 
 		ArrayList<String> errorList = new ArrayList<String>();
@@ -712,10 +772,18 @@ public class Pick implements DetectionInt {
 		if (jsonAmplitude != null) {
 			if (!jsonAmplitude.isValid()) {
 				// amplitude invalid
-				errorList.add("Invalid Amplitude in Correlation Class.");
+				errorList.add("Invalid Amplitude in Pick Class.");
 			}
 		}
 
+		// beam
+		if (jsonBeam != null) {
+			if (!jsonBeam.isValid()) {
+				// beam invalid
+				errorList.add("Invalid Beam in Pick Class.");
+			}
+		}		
+		
 		// associated
 		if (jsonAssociationInfo != null) {
 			if (!jsonAssociationInfo.isValid()) {
@@ -803,6 +871,13 @@ public class Pick implements DetectionInt {
 	 */
 	public Amplitude getAmplitude() {
 		return amplitude;
+	}
+
+	/**
+	 * @return the beam
+	 */
+	public Beam getBeam() {
+		return beam;
 	}
 
 	/**

--- a/java/src/gov/usgs/detectionformats/PickerTest.java
+++ b/java/src/gov/usgs/detectionformats/PickerTest.java
@@ -15,7 +15,9 @@ public class PickerTest {
 			+ "2.65}],\"Onset\":\"questionable\",\"Amplitude\":{\"Period\":2.65,"
 			+ "\"Amplitude\":21.5,\"SNR\":3.8},\"Time\":\"2015-12-28T21:32:24.017Z\","
 			+ "\"Site\":{\"Station\":\"BMN\",\"Channel\":\"HHZ\",\"Network\":\"LB\","
-			+ "\"Location\":\"01\",\"SiteID\":\"BMN.HHZ.LB.01\"},\"Type\":\"Pick\","
+			+ "\"Location\":\"01\"},\"Type\":\"Pick\",\"Beam\":{\"BackAzimuth\":2.65,"
+			+ "\"BackAzimuthError\":3.8,\"Slowness\":1.44,\"SlownessError\":0.4,"
+			+ "\"PowerRatio\":12.18,\"PowerRatioError\":0.557},"
 			+ "\"ID\":\"12GFH48776857\",\"Polarity\":\"up\",\"Phase\":\"P\","
 			+ "\"Picker\":\"manual\",\"AssociationInfo\":{\"Distance\":0.442559,"
 			+ "\"Azimuth\":0.418479,\"Phase\":\"P\",\"Sigma\":0.086333,\"Residual\":"
@@ -25,7 +27,6 @@ public class PickerTest {
 	public static String CHANNEL = "HHZ";
 	public static String NETWORK = "LB";
 	public static String LOCATION = "01";
-	public static String SITEID = "BMN.HHZ.LB.01";
 	public static String AGENCYID = "US";
 	public static String AUTHOR = "TestAuthor";
 	public static Date TIME = Utility.getDate("2015-12-28T21:32:24.017Z");
@@ -38,6 +39,12 @@ public class PickerTest {
 	public static double AMPLITUDE = 21.5;
 	public static double PERIOD = 2.65;
 	public static double SNR = 3.8;
+	public static double BACKAZIMUTH = 2.65;
+	public static double BACKAZIMUTHERROR = 3.8;
+	public static double SLOWNESS = 1.44;
+	public static double SLOWNESSERROR = 0.4;
+	public static double POWERRATIO = 12.18;
+	public static double POWERRATIOERROR = 0.557;
 	public static String ASSOCPHASE = "P";
 	public static double ASSOCDISTANCE = 0.442559;
 	public static double ASSOCAZIMUTH = 0.418479;
@@ -50,10 +57,12 @@ public class PickerTest {
 	@Test
 	public void writesJSON() {
 
-		Pick pickObject = new Pick(ID, SITEID, STATION, CHANNEL, NETWORK,
-				LOCATION, TIME, AGENCYID, AUTHOR, PHASE, POLARITY, ONSET,
-				PICKER, HIGHPASS, LOWPASS, AMPLITUDE, PERIOD, SNR, ASSOCPHASE,
-				ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
+		Pick pickObject = new Pick(ID, STATION, CHANNEL, NETWORK, LOCATION,
+				TIME, AGENCYID, AUTHOR, PHASE, POLARITY, ONSET, PICKER,
+				HIGHPASS, LOWPASS, AMPLITUDE, PERIOD, SNR, BACKAZIMUTH,
+				BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
+				POWERRATIOERROR, ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH,
+				ASSOCRESIDUAL, ASSOCSIGMA);
 
 		// write out to a string
 		String jsonString = Utility.toJSONString(pickObject.toJSON());
@@ -90,31 +99,37 @@ public class PickerTest {
 	public void altConstructors() {
 
 		// use constructor
-		Pick pickObject = new Pick(ID, SITEID, STATION, CHANNEL, NETWORK,
-				LOCATION, TIME, AGENCYID, AUTHOR, PHASE, POLARITY, ONSET,
-				PICKER, HIGHPASS, LOWPASS, AMPLITUDE, PERIOD, SNR);
+		Pick pickObject = new Pick(ID, STATION, CHANNEL, NETWORK, LOCATION,
+				TIME, AGENCYID, AUTHOR, PHASE, POLARITY, ONSET, PICKER,
+				HIGHPASS, LOWPASS, AMPLITUDE, PERIOD, SNR, BACKAZIMUTH,
+				BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
+				POWERRATIOERROR);
 
 		// check data values
 		checkData(pickObject, "Alternate Constructor 1");
 
 		// use constructor
 		Pick altPickObject = new Pick(ID,
-				new Site(SITEID, STATION, CHANNEL, NETWORK, LOCATION), TIME,
+				new Site(STATION, CHANNEL, NETWORK, LOCATION), TIME,
 				new Source(AGENCYID, AUTHOR), PHASE, POLARITY, ONSET, PICKER,
 				new ArrayList<Filter>(
 						Arrays.asList(new Filter(HIGHPASS, LOWPASS))),
-				new Amplitude(AMPLITUDE, PERIOD, SNR));
+				new Amplitude(AMPLITUDE, PERIOD, SNR),
+				new Beam(BACKAZIMUTH, BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR,
+						POWERRATIO, POWERRATIOERROR));
 
 		// check data values
 		checkData(altPickObject, "Alternate Constructor 2");
 
 		// use constructor
 		Pick altAltPickObject = new Pick(ID,
-				new Site(SITEID, STATION, CHANNEL, NETWORK, LOCATION), TIME,
+				new Site(STATION, CHANNEL, NETWORK, LOCATION), TIME,
 				new Source(AGENCYID, AUTHOR), PHASE, POLARITY, ONSET, PICKER,
 				new ArrayList<Filter>(
 						Arrays.asList(new Filter(HIGHPASS, LOWPASS))),
 				new Amplitude(AMPLITUDE, PERIOD, SNR),
+				new Beam(BACKAZIMUTH, BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR,
+						POWERRATIO, POWERRATIOERROR),
 				new Associated(ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH,
 						ASSOCRESIDUAL, ASSOCSIGMA));
 
@@ -128,10 +143,12 @@ public class PickerTest {
 	@Test
 	public void validate() {
 
-		Pick pickObject = new Pick(ID, SITEID, STATION, CHANNEL, NETWORK,
-				LOCATION, TIME, AGENCYID, AUTHOR, PHASE, POLARITY, ONSET,
-				PICKER, HIGHPASS, LOWPASS, AMPLITUDE, PERIOD, SNR, ASSOCPHASE,
-				ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
+		Pick pickObject = new Pick(ID, STATION, CHANNEL, NETWORK, LOCATION,
+				TIME, AGENCYID, AUTHOR, PHASE, POLARITY, ONSET, PICKER,
+				HIGHPASS, LOWPASS, AMPLITUDE, PERIOD, SNR, BACKAZIMUTH,
+				BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
+				POWERRATIOERROR, ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH,
+				ASSOCRESIDUAL, ASSOCSIGMA);
 
 		// Successful validation
 		boolean rc = pickObject.isValid();
@@ -140,10 +157,12 @@ public class PickerTest {
 		assertEquals("Successful Validation", true, rc);
 
 		// build bad Pick object
-		Pick badPickObject = new Pick("", SITEID, null, CHANNEL, NETWORK,
-				LOCATION, null, AGENCYID, AUTHOR, PHASE, POLARITY, ONSET,
-				PICKER, HIGHPASS, LOWPASS, AMPLITUDE, PERIOD, SNR, ASSOCPHASE,
-				ASSOCDISTANCE, ASSOCAZIMUTH, ASSOCRESIDUAL, ASSOCSIGMA);
+		Pick badPickObject = new Pick("", null, CHANNEL, NETWORK, LOCATION,
+				null, AGENCYID, AUTHOR, PHASE, POLARITY, ONSET, PICKER,
+				HIGHPASS, LOWPASS, AMPLITUDE, PERIOD, SNR, BACKAZIMUTH,
+				BACKAZIMUTHERROR, SLOWNESS, SLOWNESSERROR, POWERRATIO,
+				POWERRATIOERROR, ASSOCPHASE, ASSOCDISTANCE, ASSOCAZIMUTH,
+				ASSOCRESIDUAL, ASSOCSIGMA);
 
 		rc = badPickObject.isValid();
 
@@ -172,10 +191,6 @@ public class PickerTest {
 		assertEquals(TestName + " Location Equals", LOCATION,
 				pickObject.getSite().getLocation());
 
-		// check pickObject.site.SiteID
-		assertEquals(TestName + " SiteID Equals", SITEID,
-				pickObject.getSite().getSiteID());
-
 		// check pickObject.Source.AgencyID
 		assertEquals(TestName + " AgencyID Equals", AGENCYID,
 				pickObject.getSource().getAgencyID());
@@ -202,22 +217,26 @@ public class PickerTest {
 				pickObject.getPicker());
 
 		// check pickObject.FilterList
-		ArrayList<Filter> filterList = pickObject.getFilterList();
-		if (!filterList.isEmpty()) {
+		if (pickObject.getFilterList() != null) {
 
-			// get the first filter in the list
-			Filter aFilter = filterList.get(0);
+			ArrayList<Filter> filterList = pickObject.getFilterList();
+			if (!filterList.isEmpty()) {
 
-			// check aFilter.HighPass
-			assertEquals(TestName + " HighPass Equals", HIGHPASS,
-					aFilter.getHighPass(), 0);
+				// get the first filter in the list
+				Filter aFilter = filterList.get(0);
 
-			// check aFilter.LowPass
-			assertEquals(TestName + " LowPass Equals", LOWPASS,
-					aFilter.getLowPass(), 0);
+				// check aFilter.HighPass
+				assertEquals(TestName + " HighPass Equals", HIGHPASS,
+						aFilter.getHighPass(), 0);
+
+				// check aFilter.LowPass
+				assertEquals(TestName + " LowPass Equals", LOWPASS,
+						aFilter.getLowPass(), 0);
+			}
 		}
 
-		if (!pickObject.getAmplitude().isEmpty()) {
+		if ((pickObject.getAmplitude() != null)
+				&& (!pickObject.getAmplitude().isEmpty())) {
 			// check pickObject.Amplitude.Amplitude
 			assertEquals(TestName + " Amplitude Equals", AMPLITUDE,
 					pickObject.getAmplitude().getAmplitude(), 0);
@@ -229,6 +248,42 @@ public class PickerTest {
 			// check pickObject.Amplitude.SNR
 			assertEquals(TestName + " SNR Equals", SNR,
 					pickObject.getAmplitude().getSNR(), 0);
+		}
+
+		if (pickObject.getBeam() != null) {
+			// check pickObject.getBeam().BackAzimuth
+			assertEquals(TestName + " BackAzimuth Equals", BACKAZIMUTH,
+					pickObject.getBeam().getBackAzimuth(), 0);
+
+			// check pickObject.getBeam().BackAzimuthError
+			if (pickObject.getBeam().getBackAzimuthError() != null) {
+				assertEquals(TestName + " BackAzimuthError Equals",
+						BACKAZIMUTHERROR,
+						pickObject.getBeam().getBackAzimuthError(), 0);
+			}
+
+			// check pickObject.getBeam().Slowness
+			assertEquals(TestName + " Slowness Equals", SLOWNESS,
+					pickObject.getBeam().getSlowness(), 0);
+
+			// check pickObject.getBeam().SlownessError
+			if (pickObject.getBeam().getSlownessError() != null) {
+				assertEquals(TestName + " SlownessError Equals", SLOWNESSERROR,
+						pickObject.getBeam().getSlownessError(), 0);
+			}
+
+			// check pickObject.getBeam().PowerRatio
+			if (pickObject.getBeam().getPowerRatio() != null) {
+				assertEquals(TestName + " PowerRatio Equals", POWERRATIO,
+						pickObject.getBeam().getPowerRatio(), 0);
+			}
+
+			// check pickObject.getBeam().PowerRatioError
+			if (pickObject.getBeam().getPowerRatioError() != null) {
+				assertEquals(TestName + " PowerRatioError Equals",
+						POWERRATIOERROR,
+						pickObject.getBeam().getPowerRatioError(), 0);
+			}
 		}
 
 		if (!pickObject.getAssociationInfo().isEmpty()) {

--- a/java/src/gov/usgs/detectionformats/Site.java
+++ b/java/src/gov/usgs/detectionformats/Site.java
@@ -15,16 +15,10 @@ public class Site implements DetectionInt {
 	/**
 	 * JSON Keys
 	 */
-	public static final String SITEID_KEY = "SiteID";
 	public static final String STATION_KEY = "Station";
 	public static final String CHANNEL_KEY = "Channel";
 	public static final String NETWORK_KEY = "Network";
 	public static final String LOCATION_KEY = "Location";
-
-	/**
-	 * Required unique identifier for this Site
-	 */
-	private final String siteID;
 
 	/**
 	 * Required station code.
@@ -51,7 +45,6 @@ public class Site implements DetectionInt {
 	 */
 	public Site() {
 
-		siteID = null;
 		station = null;
 		channel = null;
 		network = null;
@@ -62,8 +55,6 @@ public class Site implements DetectionInt {
 	 * The advanced constructor for the Site class. Initializes members to
 	 * provided values.
 	 *
-	 * @param newSiteID
-	 *            - A String containing the siteID to use
 	 * @param newStation
 	 *            - A String containing the station to use
 	 * @param newChannel
@@ -73,10 +64,9 @@ public class Site implements DetectionInt {
 	 * @param newLocation
 	 *            - A String containing the location to use (null omit)
 	 */
-	public Site(String newSiteID, String newStation, String newChannel,
+	public Site(String newStation, String newChannel,
 			String newNetwork, String newLocation) {
 
-		siteID = newSiteID;
 		station = newStation;
 		channel = newChannel;
 		network = newNetwork;
@@ -92,13 +82,6 @@ public class Site implements DetectionInt {
 	public Site(JSONObject newJSONObject) {
 
 		// required values
-		// siteID
-		if (newJSONObject.containsKey(SITEID_KEY)) {
-			siteID = newJSONObject.get(SITEID_KEY).toString();
-		} else {
-			siteID = null;
-		}
-
 		// station
 		if (newJSONObject.containsKey(STATION_KEY)) {
 			station = newJSONObject.get(STATION_KEY).toString();
@@ -139,18 +122,12 @@ public class Site implements DetectionInt {
 
 		JSONObject NewJSONObject = new JSONObject();
 
-		String jsonSiteID = getSiteID();
 		String jsonStation = getStation();
 		String jsonNetwork = getNetwork();
 		String jsonChannel = getChannel();
 		String jsonLocation = getLocation();
 
 		// required values
-		// siteID
-		if ((jsonSiteID != null) && (!jsonSiteID.isEmpty())) {
-			NewJSONObject.put(SITEID_KEY, jsonSiteID);
-		}
-
 		// station
 		if ((jsonStation != null) && (!jsonStation.isEmpty())) {
 			NewJSONObject.put(STATION_KEY, jsonStation);
@@ -198,24 +175,13 @@ public class Site implements DetectionInt {
 	 */
 	public ArrayList<String> getErrors() {
 
-		String jsonSiteID = getSiteID();
 		String jsonStation = getStation();
 		String jsonNetwork = getNetwork();
 
 		ArrayList<String> errorList = new ArrayList<String>();
 
 		// check for required keys
-		// siteID
-		if (jsonSiteID == null) {
-			// siteID not found
-			errorList.add("No SiteID in Site Class.");
-		} else if (jsonSiteID.isEmpty()) {
-			// siteID empty
-			errorList.add("Empty SiteID in Site Class.");
-		}
-
 		// station
-		// siteID
 		if (jsonStation == null) {
 			// station not found
 			errorList.add("No Station in Site Class.");
@@ -233,7 +199,7 @@ public class Site implements DetectionInt {
 			errorList.add("Empty Network in Site Class.");
 		}
 
-		// since siteID, station, channel, network, and location are free text
+		// since station, channel, network, and location are free text
 		// strings, no further validation is required. channel and location
 		// are also optional.
 		// NOTE: Further validation COULD be done to confirm that values matched
@@ -241,13 +207,6 @@ public class Site implements DetectionInt {
 
 		// success
 		return (errorList);
-	}
-
-	/**
-	 * @return the siteID
-	 */
-	public String getSiteID() {
-		return siteID;
 	}
 
 	/**

--- a/java/src/gov/usgs/detectionformats/SiteTest.java
+++ b/java/src/gov/usgs/detectionformats/SiteTest.java
@@ -8,13 +8,11 @@ import static org.junit.Assert.*;
 public class SiteTest {
 
 	public static final String SITE_STRING = "{\"Station\":\"BMN\",\"Channel\":"
-			+ "\"HHZ\",\"Network\":\"LB\",\"Location\":\"01\",\"SiteID\":"
-			+ "\"BMN.HHZ.LB.01\"}";
+			+ "\"HHZ\",\"Network\":\"LB\",\"Location\":\"01\"}";
 	public static final String STATION = "BMN";
 	public static final String CHANNEL = "HHZ";
 	public static final String NETWORK = "LB";
 	public static final String LOCATION = "01";
-	public static final String SITEID = "BMN.HHZ.LB.01";
 
 	/**
 	 * Able to write a JSON string
@@ -22,7 +20,7 @@ public class SiteTest {
 	@Test
 	public void writesJSON() {
 
-		Site SiteObject = new Site(SITEID, STATION, CHANNEL, NETWORK, LOCATION);
+		Site SiteObject = new Site(STATION, CHANNEL, NETWORK, LOCATION);
 
 		// write out to a string
 		String jsonString = Utility.toJSONString(SiteObject.toJSON());
@@ -59,7 +57,7 @@ public class SiteTest {
 	@Test
 	public void validate() {
 
-		Site siteObject = new Site(SITEID, STATION, CHANNEL, NETWORK, LOCATION);
+		Site siteObject = new Site(STATION, CHANNEL, NETWORK, LOCATION);
 
 		// Successful validation
 		boolean rc = siteObject.isValid();
@@ -68,7 +66,7 @@ public class SiteTest {
 		assertEquals("Successful Validation", true, rc);
 
 		// build bad source object
-		Site badSiteObject = new Site(SITEID, null, null, null, null);
+		Site badSiteObject = new Site(null, null, null, null);
 
 		rc = badSiteObject.isValid();
 
@@ -96,10 +94,6 @@ public class SiteTest {
 		// check SiteObject.Location
 		assertEquals(TestName + " Location Equals", LOCATION,
 				SiteObject.getLocation());
-
-		// check SiteObject.SiteID
-		assertEquals(TestName + " SiteID Equals", SITEID,
-				SiteObject.getSiteID());
 
 	}
 


### PR DESCRIPTION
Changed the formats such that:

- Remove SiteID from site, fixing any formats, and unit tests affected.
- Convert Beam from a separate format to an object containing back azimuth, slowness, power ratio, and associated errors.
- Add Beam to Pick Format
- Remove Beam from Detection format


Fixes #16 
Fixes #15 