### PR TITLE
Bugfix to store DetectionTime in json as ISO8601

### DIFF
--- a/cpp/src/detection.cpp
+++ b/cpp/src/detection.cpp
@@ -143,9 +143,10 @@ detection::detection(rapidjson::Value &json) {
 
 	// detectiontime
 	if ((json.HasMember(DETECTIONTIME_KEY) == true)
-			&& (json[DETECTIONTIME_KEY].IsNumber() == true)
-			&& (json[DETECTIONTIME_KEY].IsDouble() == true))
-		detectiontime = json[DETECTIONTIME_KEY].GetDouble();
+			&& (json[DETECTIONTIME_KEY].IsString() == true))
+		detectiontime = detectionformats::ConvertISO8601ToEpochTime(
+				std::string(json[DETECTIONTIME_KEY].GetString(),
+						json[DETECTIONTIME_KEY].GetStringLength()));
 	else
 		detectiontime = std::numeric_limits<double>::quiet_NaN();
 
@@ -287,8 +288,14 @@ rapidjson::Value & detection::tojson(rapidjson::Value &json,
 	}
 
 	// detectiontime
-	if (std::isnan(detectiontime) != true)
-		json.AddMember(DETECTIONTIME_KEY, detectiontime, allocator);
+	if (std::isnan(detectiontime) != true) {
+		std::string timestring = detectionformats::ConvertEpochTimeToISO8601(
+				detectiontime);
+		rapidjson::Value timevalue;
+		timevalue.SetString(rapidjson::StringRef(timestring.c_str()),
+				allocator);
+		json.AddMember(DETECTIONTIME_KEY, timevalue, allocator);
+	}
 
 	// eventtype
 	if (eventtype != "") {

--- a/cpp/tests/detection_unittest.cpp
+++ b/cpp/tests/detection_unittest.cpp
@@ -84,7 +84,6 @@ void checkdata(detectionformats::detection detectionobject,
 	double expectedtime = detectionformats::ConvertISO8601ToEpochTime(
 			std::string(ORIGINTIME));
 	ASSERT_NEAR(time, expectedtime, 0.0001);
-	//ASSERT_EQ(time, expectedtime);
 
 	// check depth
 	double depth = detectionobject.hypocenter.depth;
@@ -134,7 +133,6 @@ void checkdata(detectionformats::detection detectionobject,
 				detectionformats::ConvertISO8601ToEpochTime(
 						std::string(DETECTIONTIME));
 		ASSERT_NEAR(detectiontime, expecteddetectiontime, 0.0001);
-		//ASSERT_EQ(detectiontime, expecteddetectiontime);
 	}
 
 	// check eventtype


### PR DESCRIPTION
Accidentally stored DetectionTime as an epoch time, which doesn't match the format spec.
Also removed some commented out test calls.