### PR TITLE
Include Fix

### DIFF
--- a/cpp/include/amplitude.h
+++ b/cpp/include/amplitude.h
@@ -7,11 +7,11 @@
 #ifndef DETECTION_AMPLITUDE_H
 #define DETECTION_AMPLITUDE_H
 
-#include <base.h>
-
 #include <string>
 #include <exception>
 #include <vector>
+
+#include "./base.h"
 
 namespace detectionformats {
 /**

--- a/cpp/include/associated.h
+++ b/cpp/include/associated.h
@@ -7,11 +7,11 @@
 #ifndef DETECTION_ASSOCIATED_H
 #define DETECTION_ASSOCIATED_H
 
-#include <base.h>
-
 #include <string>
 #include <exception>
 #include <vector>
+
+#include "./base.h"
 
 namespace detectionformats {
 /**

--- a/cpp/include/base.h
+++ b/cpp/include/base.h
@@ -7,11 +7,11 @@
 #ifndef DETECTION_BASE_H
 #define DETECTION_BASE_H
 
-#include <util.h>
-
 #include <string>
 #include <vector>
 #include <cmath>
+
+#include "./util.h"
 
 namespace detectionformats {
 class detectionbase {

--- a/cpp/include/beam.h
+++ b/cpp/include/beam.h
@@ -7,11 +7,11 @@
 #ifndef DETECTION_BEAM_H
 #define DETECTION_BEAM_H
 
-#include <site.h>
-#include <source.h>
-
 #include <string>
 #include <vector>
+
+#include "./site.h"
+#include "./source.h"
 
 namespace detectionformats {
 

--- a/cpp/include/correlation.h
+++ b/cpp/include/correlation.h
@@ -7,13 +7,13 @@
 #ifndef DETECTION_CORRELATION_H
 #define DETECTION_CORRELATION_H
 
-#include <hypocenter.h>
-#include <site.h>
-#include <source.h>
-#include <associated.h>
-
 #include <string>
 #include <vector>
+
+#include "./hypocenter.h"
+#include "./site.h"
+#include "./source.h"
+#include "./associated.h"
 
 namespace detectionformats {
 

--- a/cpp/include/detection-formats.h
+++ b/cpp/include/detection-formats.h
@@ -1,15 +1,15 @@
 #ifndef DETECTION_H
 #define DETECTION_H
 
-#include <hypocenter.h>
-#include <detection.h>
-#include <retract.h>
-#include <pick.h>
-#include <beam.h>
-#include <correlation.h>
-#include <util.h>
-#include <base.h>
-#include <stationInfo.h>
-#include <stationInfoRequest.h>
+#include "./hypocenter.h"
+#include "./detection.h"
+#include "./retract.h"
+#include "./pick.h"
+#include "./beam.h"
+#include "./correlation.h"
+#include "./util.h"
+#include "./base.h"
+#include "./stationInfo.h"
+#include "./stationInfoRequest.h"
 
 #endif  // DETECTION_H

--- a/cpp/include/detection.h
+++ b/cpp/include/detection.h
@@ -7,13 +7,13 @@
 #ifndef DETECTION_ORIGIN_H
 #define DETECTION_ORIGIN_H
 
-#include <source.h>
-#include <hypocenter.h>
-#include <pick.h>
-#include <correlation.h>
-
 #include <string>
 #include <vector>
+
+#include "./source.h"
+#include "./hypocenter.h"
+#include "./pick.h"
+#include "./correlation.h"
 
 namespace detectionformats {
 /**

--- a/cpp/include/filter.h
+++ b/cpp/include/filter.h
@@ -7,11 +7,11 @@
 #ifndef DETECTION_FILTER_H
 #define DETECTION_FILTER_H
 
-#include <base.h>
-
 #include <string>
 #include <exception>
 #include <vector>
+
+#include "./base.h"
 
 namespace detectionformats {
 /**

--- a/cpp/include/hypocenter.h
+++ b/cpp/include/hypocenter.h
@@ -7,11 +7,11 @@
 #ifndef DETECTION_HYPOCENTER_H
 #define DETECTION_HYPOCENTER_H
 
-#include <base.h>
-
 #include <string>
 #include <exception>
 #include <vector>
+
+#include "./base.h"
 
 namespace detectionformats {
 /**

--- a/cpp/include/pick.h
+++ b/cpp/include/pick.h
@@ -7,15 +7,15 @@
 #ifndef DETECTION_PICK_H
 #define DETECTION_PICK_H
 
-#include <site.h>
-#include <source.h>
-#include <amplitude.h>
-#include <filter.h>
-#include <beam.h>
-#include <associated.h>
-
 #include <string>
 #include <vector>
+
+#include "./site.h"
+#include "./source.h"
+#include "./amplitude.h"
+#include "./filter.h"
+#include "./beam.h"
+#include "./associated.h"
 
 namespace detectionformats {
 

--- a/cpp/include/retract.h
+++ b/cpp/include/retract.h
@@ -7,10 +7,10 @@
 #ifndef DETECTION_RETRACT_H
 #define DETECTION_RETRACT_H
 
-#include <source.h>
-
 #include <string>
 #include <vector>
+
+#include "./source.h"
 
 namespace detectionformats {
 /**

--- a/cpp/include/site.h
+++ b/cpp/include/site.h
@@ -7,11 +7,11 @@
 #ifndef DETECTION_SITE_H
 #define DETECTION_SITE_H
 
-#include <base.h>
-
 #include <string>
 #include <exception>
 #include <vector>
+
+#include "./base.h"
 
 namespace detectionformats {
 /**

--- a/cpp/include/source.h
+++ b/cpp/include/source.h
@@ -7,11 +7,11 @@
 #ifndef DETECTION_SOURCE_H
 #define DETECTION_SOURCE_H
 
-#include <base.h>
-
 #include <string>
 #include <exception>
 #include <vector>
+
+#include "./base.h"
 
 namespace detectionformats {
 /**

--- a/cpp/include/stationInfo.h
+++ b/cpp/include/stationInfo.h
@@ -7,12 +7,12 @@
 #ifndef STATION_INFO_H
 #define STATION_INFO_H
 
-#include <site.h>
-#include <source.h>
-
 #include <string>
 #include <exception>
 #include <vector>
+
+#include "./site.h"
+#include "./source.h"
 
 namespace detectionformats {
 

--- a/cpp/include/stationInfoRequest.h
+++ b/cpp/include/stationInfoRequest.h
@@ -7,12 +7,12 @@
 #ifndef STATION_INFO_REQUEST_H
 #define STATION_INFO_REQUEST_H
 
-#include <site.h>
-#include <source.h>
-
 #include <string>
 #include <exception>
 #include <vector>
+
+#include "./site.h"
+#include "./source.h"
 
 namespace detectionformats {
 


### PR DESCRIPTION
This PR changes the <...> include style to "..." for detection formats headers.

This change was made because in some projects that use detection formats had header collisions (i.e. both projects had a site.h) this lead to build errors in the dependent projects.

The includes also have the directory ("./site.h") and have been moved below cpp includes because that is what the code style requires.