### PR TITLE
Added support for reading an int as a double for aziumuth and distance

### DIFF
--- a/cpp/src/classification.cpp
+++ b/cpp/src/classification.cpp
@@ -106,9 +106,14 @@ classification::classification(rapidjson::Value &json) {
 
 	// distance
 	if ((json.HasMember(DISTANCE_KEY) == true)
-			&& (json[DISTANCE_KEY].IsNumber() == true)
-			&& (json[DISTANCE_KEY].IsDouble() == true)) {
-		distance = json[DISTANCE_KEY].GetDouble();
+			&& (json[DISTANCE_KEY].IsNumber() == true)) {
+		if (json[DISTANCE_KEY].IsDouble() == true) {
+			distance = json[DISTANCE_KEY].GetDouble();
+		} else if (json[DISTANCE_KEY].IsInt() == true) {
+			distance = static_cast<double>(json[DISTANCE_KEY].GetInt());
+		} else {
+			distance = std::numeric_limits<double>::quiet_NaN();
+		}
 	} else {
 		distance = std::numeric_limits<double>::quiet_NaN();
 	}
@@ -124,9 +129,14 @@ classification::classification(rapidjson::Value &json) {
 
 	// azimuth
 	if ((json.HasMember(AZIMUTH_KEY) == true)
-			&& (json[AZIMUTH_KEY].IsNumber() == true)
-			&& (json[AZIMUTH_KEY].IsDouble() == true)) {
-		azimuth = json[AZIMUTH_KEY].GetDouble();
+			&& (json[AZIMUTH_KEY].IsNumber() == true)) {
+		if (json[AZIMUTH_KEY].IsDouble() == true) {
+			azimuth = json[AZIMUTH_KEY].GetDouble();
+		} else if (json[AZIMUTH_KEY].IsInt() == true) {
+			azimuth = static_cast<double>(json[AZIMUTH_KEY].GetInt());
+		} else {
+			azimuth = std::numeric_limits<double>::quiet_NaN();
+		}
 	} else {
 		azimuth = std::numeric_limits<double>::quiet_NaN();
 	}


### PR DESCRIPTION
Detection Formats (c++) was incorrectly not reading an integer value in the azimuth or distance fields due to the code enforcing that it would only read double values (and the message storing those values as ints because that's how the python generator wrote them). This same restriction exists for most doubles in the library, so a future pass to apply this fix more generally may be in order.